### PR TITLE
Update FullPrivacy.tsx to remove /fr/ from link

### DIFF
--- a/client/src/scenes/Settings/Importer/FullPrivacy/FullPrivacy.tsx
+++ b/client/src/scenes/Settings/Importer/FullPrivacy/FullPrivacy.tsx
@@ -40,7 +40,7 @@ export default function FullPrivacy() {
         Read more{' '}
         <a
           target="_blank"
-          href="https://www.spotify.com/fr/account/privacy/"
+          href="https://www.spotify.com/account/privacy/"
           rel="noreferrer">
           here
         </a>


### PR DESCRIPTION
Change localized link: https://www.spotify.com/fr/account/privacy/

To the generic: https://www.spotify.com/account/privacy/

Currently, this link redirects me to the French version of the site, but I am in the US.  The new link should dynamically redirect users to their localized version of the site.