### PR TITLE
Add note about Google False positives with this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ It's composed of a web server which polls the Spotify API every now and then and
 2. You need to provide the **Server** environment the **public** AND **secret** key of the application (cf. [Installation](#installation)).
 3. You need to provide an **authorized** redirect URI to the `docker-compose` file.
 
+## Domains
+
+A note of caution: It is strongly advised to refrain from using the word 'spotify' in your domain, as Google has a history of flagging not only your subdomain but also all other associated subdomains and the root domain as deceptive websites. This can result in users being unable to access any of your websites through popular browsers like Google Chrome, Safari, or Firefox due to a false positive.
+
 > A tutorial is available at the end of this readme.
 
 # Installation


### PR DESCRIPTION
## The problem

Today I noticed that all of my subdomains, including my personal website, are marked as "Deceptive":

<img width="740" alt="image" src="https://github.com/Yooooomi/your_spotify/assets/3074765/c67c433f-27b9-48ca-b8eb-4823d0a63bc9">

<img width="718" alt="image" src="https://github.com/Yooooomi/your_spotify/assets/3074765/0b3199c2-9c97-4082-ae5d-18632d536eec">

I was hosting this repo at `spotify.ep.jnadeau.ca` for personal use, restricted it to only allow myself to login, and Google's AI marked all of my websites as deceptive as a result. I've since moved this to a different domain behind basic auth as well.

## Why this change?

I can only assume that their AI has made the conclusion that I was phishing as the domain has `spotify` in the title and the log in page looks somewhat like Spotify's.

This PR thus adds a warning to the README as a proposed mitigation for users.

## What else can be done?

This PR is a very basic mitigation. I would also suggest that the login page changes

| Spotify | Your Spotify |
| --- | --- |
|  <img width="1010" alt="image" src="https://github.com/Yooooomi/your_spotify/assets/3074765/23187869-4b38-4e06-b47b-870dd0955c0b"> | <img width="736" alt="image" src="https://github.com/Yooooomi/your_spotify/assets/3074765/38c3e66b-2b29-440c-a4c1-f9f03d2c3ee3"> |

In this comparison we see that the overall login page is quite different, but the typography and button style are quite similar.

I'd suggest the button style be changed and typography be changed, or perhaps a warning alert added to indicate this is not spotify. 


