### PR TITLE
Exit on unrecoverable errors in `dbLoop`

### DIFF
--- a/server/src/bin/www.ts
+++ b/server/src/bin/www.ts
@@ -77,5 +77,9 @@ connect().then(async () => {
       'Spotify was detected in CLIENT_ENDPOINT, Google might mark your entire domain as deceptive. https://github.com/Yooooomi/your_spotify/pull/254',
     );
   }
-  dbLoop().catch(logger.error);
+  dbLoop().catch(err => {
+    logger.error(err);
+
+    process.exit(1);
+  });
 });


### PR DESCRIPTION
This PR addresses issue #275, which had been closed without a definitive resolution. The solution proposed by this pull request is a straightforward one, without any complicated retry mechanisms. As elaborated in the [commit description](https://github.com/Yooooomi/your_spotify/pull/297/commits/dead24f07a9df5a2630fb4a0fd55783fe0d36498), this patch ensures that unrecoverable errors thrown within `dbLoop()` do not get "swallowed" by the `catch()` in `src/bin/www.ts`. Consequently, it prevents the server from entering an idle state where it continues to run without importing any recently played songs, a scenario that will result in unexpected data loss.

I remain committed to seeing this issue through to resolution. Although my previous comments in the issue may have come across as emotionally charged, they were not intended to be disrespectful. My sincere intention is to contribute positively to this project. Thank you for your understanding, it's all love.