### PR TITLE
Fix admin user api endpoint

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -137,7 +137,7 @@ router.put(
 
     try {
       const users = await getAllAdmins();
-      if (users.length <= 1) {
+      if (users.length <= 1 && status === false) {
         return res.status(400).send({ code: 'CANNOT_HAVE_ZERO_ADMIN' });
       }
       await setUserAdmin(id, status);


### PR DESCRIPTION
Initially there is always only one Admin user after setting the application up. As consequence `users.length <=1`will always be true and the API endpoints responds with the error code 400 upon trying to add an additional admin user.
This fix adds a validation which checks if an admin user is removed or added.  
The error response will only be sent upon removal.