### PR TITLE
README: Update app creation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can edit the CORS for the server:
 # Creating the Spotify Application
 
 For **YourSpotify** to work you need to provide a Spotify application **public** AND **secret** to the server environment.
-To do so, you need to create a **Spotify application** [here](https://developer.spotify.com/dashboard/applications).
+To do so, you need to create a **Spotify application** [here](https://developer.spotify.com/dashboard/create).
 
 1. Click on **Create a client ID**.
 2. Fill out all the informations.


### PR DESCRIPTION
The instructions in readme are out of date, spotify has changed ther website.

- https://developer.spotify.com/dashboard/create:

<img alt="image" src="https://github.com/Yooooomi/your_spotify/assets/199095/dd5907c2-4008-42f3-bc08-dd83469dc54e">

The old instructions (wth screenshots) can be seen here:
- https://breadnet.co.uk/your-spotify-2022/

seems spotify switched from pub/priv key part to client_id/client_secret?
