### PR TITLE
Improve Songs/Artists/Albums query performances by ~50

### DIFF
--- a/apps/server/src/database/queries/statsTools.ts
+++ b/apps/server/src/database/queries/statsTools.ts
@@ -2,6 +2,7 @@ import { PipelineStage, Types } from "mongoose";
 import { getWithDefault } from "../../tools/env";
 import { Timesplit } from "../../tools/types";
 import { User } from "../schemas/user";
+import { InfosModel } from "../Models";
 
 export const basicMatch = (
   userId: string | Types.ObjectId,
@@ -182,3 +183,68 @@ export const lightArtistLookupPipeline = (
   from: "artists",
   as: "artist",
 });
+
+export const getBestInfos = (
+  idField: string,
+  user: User,
+  start: Date,
+  end: Date,
+  nb: number,
+  offset: number,
+) =>
+  InfosModel.aggregate([
+    { $match: basicMatch(user._id, start, end) },
+    {
+      $group: {
+        _id: `$${idField}`,
+        duration_ms: { $sum: "$durationMs" },
+        count: { $sum: 1 },
+        trackId: { $first: "$id" },
+        albumId: { $first: "$albumId" },
+        primaryArtistId: { $first: "$primaryArtistId" },
+        trackIds: { $addToSet: "$id" },
+      },
+    },
+    { $addFields: { differents: { $size: "$trackIds" } } },
+    {
+      $facet: {
+        infos: [
+          { $sort: { count: -1, _id: 1 } },
+          { $skip: offset },
+          { $limit: nb },
+        ],
+        computations: [
+          {
+            $group: {
+              _id: null,
+              total_duration_ms: { $sum: "$duration_ms" },
+              total_count: { $sum: "$count" },
+            },
+          },
+        ],
+      },
+    },
+    { $unwind: "$infos" },
+    { $unwind: "$computations" },
+    {
+      $project: {
+        _id: "$infos._id",
+        result: {
+          $mergeObjects: ["$infos", "$computations"],
+        },
+      },
+    },
+    {
+      $replaceRoot: {
+        newRoot: {
+          $mergeObjects: ["$result", { _id: "$_id" }],
+        },
+      },
+    },
+    { $lookup: lightTrackLookupPipeline("trackId") },
+    { $unwind: "$track" },
+    { $lookup: lightAlbumLookupPipeline("albumId") },
+    { $unwind: "$album" },
+    { $lookup: lightArtistLookupPipeline("primaryArtistId", false) },
+    { $unwind: "$artist" },
+  ]);


### PR DESCRIPTION
While requests are performant for many use cases, I have around 225000 listened songs (23000 different) with Your Spotify hosted on a Raspberry PI, so navigate on the client takes a lot of time, especially with the "Last year" or "All" timeframe.

This PR improves performances of `getBestSongsNbOffseted`, `getBestArtistsNbOffseted` and `getBestAlbumsNbOffseted` by a factor of ~10. My approach was to group all `Infos` of the same track at start. This avoids to compute many times the same `Info`, which helps a lot for the `lightTrackLookupPipeline`.

## Benchmark

*done on mac m1, not on the Raspberry*

A request for the top songs with date range "All" before this PR takes in my case `11,8s`:

```
server  | GET /spotify/top/songs?start=2017-11-18T12:18:39.000Z&end=2024-02-26T14:07:27.570Z&nb=20&offset=0 200 11764.380 ms - 25715
```

After this PR, this time drops to `1,4s`, which makes the page loads almost instantly for the biggest request.

```
server  | GET /spotify/top/songs?start=2017-11-18T12:18:39.000Z&end=2024-02-26T14:07:27.570Z&nb=20&offset=0 200 1363.197 ms - 25095
```

**Update:** See below for another performance boost (https://github.com/Yooooomi/your_spotify/pull/348#issuecomment-1967481756)

## For reviewer

- I removed the `$project: { ...getGroupByDateProjection(user.settings.timezone), id: 1 }` step. I'm not sure what it does exactly. However, we can add it back if necessary.
- I never used MongoDB so feel free to check if some steps can be simplified. I didn't test on previous versions of Mongo, so I'm not sure if I break compatibility with Mongo 4.4 required for Raspberry Pi 4 (even if I don't see where it could happen).

## Related

#232, #162