### PR TITLE
design: Remove header background

### DIFF
--- a/apps/client/src/components/ButtonsHeader/ButtonsHeader.tsx
+++ b/apps/client/src/components/ButtonsHeader/ButtonsHeader.tsx
@@ -30,7 +30,11 @@ export default function ButtonsHeader({ items }: ButtonsHeaderProps) {
   );
 
   return (
-    <Tabs value={tab} onChange={(_, v) => goto(v)} textColor="secondary">
+    <Tabs
+      value={tab}
+      onChange={(_, v) => goto(v)}
+      textColor="secondary"
+      className={s.tabs}>
       {items.map((item, k) => (
         <Tab
           className={s.item}

--- a/apps/client/src/components/ButtonsHeader/index.module.css
+++ b/apps/client/src/components/ButtonsHeader/index.module.css
@@ -1,3 +1,14 @@
+.tabs {
+  border-bottom: 1px solid var(--divider);
+  margin-bottom: 16px;
+}
+
+@media screen and (max-width: 960px) {
+    .tabs {
+        margin-bottom: 8px;
+    }
+}
+
 .item {
   border-radius: var(--radius) !important;
 }

--- a/apps/client/src/components/ChartCard/index.module.css
+++ b/apps/client/src/components/ChartCard/index.module.css
@@ -15,17 +15,6 @@
   margin-bottom: 16px;
 }
 
-.root > div > h3::before {
-  content: '';
-  position: relative;
-  display: inline-block;
-  width: 16px;
-  height: 32px;
-  background-color: var(--text-on-light);
-  margin-right: 16px;
-  border-radius: 6px;
-}
-
 .title {
   display: flex;
   flex-direction: row;

--- a/apps/client/src/components/Header/index.module.css
+++ b/apps/client/src/components/Header/index.module.css
@@ -4,7 +4,7 @@
   align-items: center;
   justify-content: space-between;
 
-  background-color: var(--header-background);
+  background-color: var(--content-background);
   padding: 16px;
 }
 

--- a/apps/client/src/components/TitleCard/index.module.css
+++ b/apps/client/src/components/TitleCard/index.module.css
@@ -10,7 +10,7 @@
 }
 
 .container {
-  padding: 16px;
+  padding: 16px 20px;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -28,17 +28,6 @@
 
 .title > :last-child {
   margin-left: auto;
-}
-
-.title::before {
-  content: '';
-  position: relative;
-  display: inline-block;
-  width: 16px;
-  height: 32px;
-  background-color: var(--primary);
-  margin-right: 16px;
-  border-radius: 6px;
 }
 
 .content {

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -34,7 +34,7 @@ h6 {
 :root {
   --track-options: 34px;
   --radius: 6px;
-  --page-padding: 16px;
+  --page-padding: 0 16px 16px 16px;
   --accent: #FB717B;
   --header-image-size: 60px;
 }
@@ -51,7 +51,6 @@ h6 {
   --hover: rgb(65, 65, 65);
 
   --background: black;
-  --header-background: black;
   --content-background: black;
 
   --text-on-light: white;
@@ -73,8 +72,7 @@ h6 {
   --hover: #eaeaea;
 
   --background: white;
-  --header-background: white;
-  --content-background: #f7f7f7;
+  --content-background: #f2f3f6;
 
   --text-on-light: black;
   --text-on-dark: white;
@@ -91,7 +89,7 @@ h6 {
 
 @media screen and (max-width: 960px) {
   :root {
-    --page-padding: 8px;
+    --page-padding: 0px 8px 8px 8px;
     --header-image-size: 40px;
   }
 }

--- a/apps/client/src/services/theme.ts
+++ b/apps/client/src/services/theme.ts
@@ -30,7 +30,7 @@ export const useTheme = () => {
           MuiTabs: {
             styleOverrides: {
               root: {
-                backgroundColor: "var(--header-background)",
+                backgroundColor: "var(--content-background)",
               },
             },
           },


### PR DESCRIPTION
- Improve background contrast with the cards
- Remove the blocks before titles (they seem to be too much now that the cards are well defined)
- And remove header background for a more modern look

Since design changes can be controversial I'm very open to 'request changes', and you can close it if you don't like it

# Before

<img width="1789" alt="image" src="https://github.com/Yooooomi/your_spotify/assets/12123721/fd714cdd-9b16-4f9e-94a4-f93f48402e6e">

# After

<img width="1789" alt="image" src="https://github.com/Yooooomi/your_spotify/assets/12123721/1f284727-487a-4c4e-b848-67380ab9d989">