### PR TITLE
Respect COOKIE_VALIDITY_MS setting in production

### DIFF
--- a/apps/server/src/routes/oauth.ts
+++ b/apps/server/src/routes/oauth.ts
@@ -66,7 +66,7 @@ router.get("/spotify/callback", withGlobalPreferences, async (req, res) => {
       { userId: user._id.toString() },
       privateData.jwtPrivateKey,
       {
-        expiresIn: "1h",
+        expiresIn: getWithDefault("COOKIE_VALIDITY_MS", "1h"),
       },
     );
     res.cookie("token", token);


### PR DESCRIPTION
The `COOKIE_VALIDITY_MS` environment variable is supposed to configure how long issued session cookies are valid for. However, before this commit, this setting was only respected when the `OFFLINE_DEV_ID` setting (which seems to be used for local testing during development) is enabled.

This commit changes this so the configured validity period also gets applied to session cookies issued using the Spotify login OAuth flow.