### PR TITLE
Set `use-credentials` for manifest file

### DIFF
--- a/apps/client/public/index.html
+++ b/apps/client/public/index.html
@@ -16,7 +16,7 @@
 
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials" />
   <script src="%PUBLIC_URL%/variables.js"></script>
 
   <title>Your Spotify</title>


### PR DESCRIPTION
### Short description:
Fixing a problem with inaccessible manifest file when using HTTP basic auth.

### Long description:
I am using nginx + basic auth for `your_spotify` frontend.
After the last update, I can no longer see the left sidebar in Chrome. In Safari it works fine.

So on chrome page looks like that (artist and song information are hidden by me):
<img width="1678" alt="Screenshot 2024-05-09 at 20 51 01" src="https://github.com/Yooooomi/your_spotify/assets/11377013/9830858b-0815-42c7-82cd-eba82e1a3b32">

After a little investigation I found that `manifest.json` cannot be loaded, and the problem is that it does not use auth headers when making the request:
<img width="569" alt="Screenshot 2024-05-09 at 20 26 30" src="https://github.com/Yooooomi/your_spotify/assets/11377013/2bdb2980-17c0-43a8-9247-5761282ca3ab">

The situation is described here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_web_manifest_with_credentials

Thus, this PR fixes this problem.