### PR TITLE
fix: missing album/artist/track in database

### DIFF
--- a/apps/server/src/database/queries/tools.ts
+++ b/apps/server/src/database/queries/tools.ts
@@ -34,15 +34,22 @@ export const getTracksWithoutAlbum = () =>
   ]);
 
 export const getAlbumsWithoutArtist = () =>
-  AlbumModel.aggregate<Album>([
+    AlbumModel.aggregate<Album>([
+    { $unwind: '$artists' },
     {
       $lookup: {
-        from: "artists",
-        as: "full_artist",
-        localField: "album",
-        foreignField: "id",
-      },
+        from: 'artists',
+        localField: 'artists',
+        foreignField: 'id',
+        as: 'artistDetails'
+      }
     },
-    { $unwind: "$full_artist" },
-    { $match: { full_artist: null } },
-  ]);
+    { $match: { artistDetails: { $eq: [] } } },
+    {
+      $group: {
+        _id: '$id',
+        album: { $first: '$$ROOT' }
+      }
+    },
+    { $replaceRoot: { newRoot: '$album' } }
+]);

--- a/apps/server/src/database/queries/user.ts
+++ b/apps/server/src/database/queries/user.ts
@@ -241,10 +241,17 @@ export const getSongs = async (
       ],
     },
   });
+
   if (!fullUser) {
     return [];
   }
-  return fullUser.tracks;
+
+  // Filter out invalid tracks
+  const validTracks = fullUser.tracks.filter((track: any) => {
+    return track.track.full_album !== null && track.track.full_artist.length > 0;
+  });
+
+  return validTracks;
 };
 
 export const getUserCount = () => UserModel.countDocuments();

--- a/apps/server/src/migrations/1708973485301-add_metadata_to_infos.ts
+++ b/apps/server/src/migrations/1708973485301-add_metadata_to_infos.ts
@@ -10,7 +10,7 @@ export async function up() {
 
   for await (const user of UserModel.find()) {
     for await (const info of InfosModel.find({ owner: user._id })) {
-      const [track] = await getTracks([info.id]);
+      const [track] = await getTracks(user._id.toString(), [info.id]);
       if (!track) {
         continue;
       }

--- a/apps/server/src/routes/album.ts
+++ b/apps/server/src/routes/album.ts
@@ -22,8 +22,9 @@ router.get(
   isLoggedOrGuest,
   async (req, res) => {
     try {
+      const { user } = req as LoggedRequest;
       const { ids } = req.params as TypedPayload<typeof getAlbumsSchema>;
-      const albums = await getAlbums(ids.split(","));
+      const albums = await getAlbums(user._id.toString(), ids.split(","));
       if (!albums || albums.length === 0) {
         return res.status(404).end();
       }
@@ -47,14 +48,14 @@ router.get(
     try {
       const { user } = req as LoggedRequest;
       const { id } = req.params as TypedPayload<typeof getAlbumStats>;
-      const [album] = await getAlbums([id]);
+      const [album] = await getAlbums(user._id.toString(), [id]);
       if (!album) {
         return res.status(404).end();
       }
       const promises = [
         getFirstAndLastListenedAlbum(user, id),
         getAlbumSongs(user, id),
-        getArtists(album.artists),
+        getArtists(user._id.toString(), album.artists),
         // getTotalListeningOfAlbum(user, id),
       ];
       const [firstLast, tracks, artists] = await Promise.all(promises);
@@ -79,7 +80,7 @@ router.get(
     try {
       const { user } = req as LoggedRequest;
       const { id } = req.params as TypedPayload<typeof getAlbumStats>;
-      const [album] = await getAlbums([id]);
+      const [album] = await getAlbums(user._id.toString(), [id]);
       if (!album) {
         return res.status(404).end();
       }

--- a/apps/server/src/routes/artist.ts
+++ b/apps/server/src/routes/artist.ts
@@ -32,8 +32,9 @@ router.get(
   isLoggedOrGuest,
   async (req, res) => {
     try {
+      const { user } = req as LoggedRequest;
       const { ids } = req.params as TypedPayload<typeof getArtistsSchema>;
-      const artists = await getArtists(ids.split(","));
+      const artists = await getArtists(user._id.toString(), ids.split(","));
       if (!artists || artists.length === 0) {
         return res.status(404).end();
       }
@@ -58,7 +59,7 @@ router.get(
       const { user } = req as LoggedRequest;
       const { id } = req.params as TypedPayload<typeof getArtistStats>;
 
-      const [artist] = await getArtists([id]);
+      const [artist] = await getArtists(user._id.toString(), [id]);
       if (!artist) {
         return res.status(404).end();
       }
@@ -108,7 +109,7 @@ router.get(
     const { id } = req.params as TypedPayload<typeof getArtistStats>;
 
     try {
-      const [artist] = await getArtists([id]);
+      const [artist] = await getArtists(user._id.toString(), [id]);
       if (!artist) {
         return res.status(404).end();
       }

--- a/apps/server/src/routes/track.ts
+++ b/apps/server/src/routes/track.ts
@@ -27,8 +27,9 @@ router.get(
   isLoggedOrGuest,
   async (req, res) => {
     try {
+      const { user } = req as LoggedRequest;
       const { ids } = req.params as TypedPayload<typeof getTracksSchema>;
-      const tracks = await getTracks(ids.split(","));
+      const tracks = await getTracks(user._id.toString(), ids.split(","));
       if (!tracks || tracks.length === 0) {
         return res.status(404).end();
       }
@@ -52,15 +53,15 @@ router.get(
     try {
       const { user } = req as LoggedRequest;
       const { id } = req.params as TypedPayload<typeof getTrackStats>;
-      const [track] = await getTracks([id]);
+      const [track] = await getTracks(user._id.toString(), [id]);
       const [trackArtist] = track?.artists ?? [];
       if (!track || !trackArtist) {
         return res.status(404).end();
       }
       const promises = [
-        getAlbums([track.album]),
+        getAlbums(user._id.toString(), [track.album]),
         getTrackListenedCount(user, id),
-        getArtists([trackArtist]),
+        getArtists(user._id.toString(), [trackArtist]),
         getTrackFirstAndLastListened(user, track.id),
         bestPeriodOfTrack(user, track.id),
         getTrackRecentHistory(user, track.id),
@@ -97,7 +98,7 @@ router.get(
     const { id } = req.params as TypedPayload<typeof getTrackStats>;
 
     try {
-      const [track] = await getTracks([id]);
+      const [track] = await getTracks(user._id.toString(), [id]);
       if (!track) {
         return res.status(404).end();
       }


### PR DESCRIPTION
fixes #429 by re-fetching missing album, artist, or track data from Spotify when it is not found (or invalid) in the database. This ensures that the relevant data is added to the database and prevents page failures or repeated requests.