### PR TITLE
Fix calculation of negative percentages in `getPercentMore`

### DIFF
--- a/apps/client/src/services/stats.ts
+++ b/apps/client/src/services/stats.ts
@@ -323,5 +323,5 @@ export const getPercentMore = (old: number, now: number) => {
   if (now > old) {
     return Math.floor((now / old - 1) * 100);
   }
-  return -(1 - Math.floor(old / now));
+  return Math.floor((1 - now / old) * 100) * -1;
 };


### PR DESCRIPTION
The `getPercentMore` function had an issue in calculating percentage decreases when `now` was less than `old`.

## Before

![image](https://github.com/user-attachments/assets/f4052883-604d-4e96-8584-3460878830a5)

## After

![image](https://github.com/user-attachments/assets/8d75b7b6-8547-49cc-b473-4ad1c2d3b0b6)
