### PR TITLE
fix: update Spotify extended streaming history schema to match new format

### DIFF
--- a/apps/server/src/tools/importers/full_privacy.ts
+++ b/apps/server/src/tools/importers/full_privacy.ts
@@ -29,12 +29,10 @@ import {
 const fullPrivacyFileSchema = z.array(
   z.object({
     ts: z.string(),
-    username: z.string().nullable(),
     platform: z.string().nullable(),
     ms_played: z.number(),
     conn_country: z.string().nullable(),
-    ip_addr_decrypted: z.string().nullable(),
-    user_agent_decrypted: z.string().nullable(),
+    ip_addr: z.string().nullable(),
     master_metadata_track_name: z.string().nullable(),
     master_metadata_album_artist_name: z.string().nullable(),
     master_metadata_album_album_name: z.string().nullable(),

--- a/apps/server/src/tools/importers/full_privacy.ts
+++ b/apps/server/src/tools/importers/full_privacy.ts
@@ -29,24 +29,10 @@ import {
 const fullPrivacyFileSchema = z.array(
   z.object({
     ts: z.string(),
-    platform: z.string().nullable(),
     ms_played: z.number(),
-    conn_country: z.string().nullable(),
-    ip_addr: z.string().nullable(),
+    spotify_track_uri: z.string().nullable(),
     master_metadata_track_name: z.string().nullable(),
     master_metadata_album_artist_name: z.string().nullable(),
-    master_metadata_album_album_name: z.string().nullable(),
-    spotify_track_uri: z.string().nullable(),
-    episode_name: z.string().nullable(),
-    episode_show_name: z.string().nullable(),
-    spotify_episode_uri: z.string().nullable(),
-    reason_start: z.string().nullable(),
-    reason_end: z.string().nullable(),
-    shuffle: z.boolean().nullable(),
-    skipped: z.boolean().nullable(),
-    offline: z.boolean().nullable(),
-    offline_timestamp: z.number().nullable(),
-    incognito_mode: z.boolean().nullable(),
   }),
 );
 
@@ -248,7 +234,7 @@ export class FullPrivacyImporter
       );
       if (!spotifyId) {
         logger.warn(
-          `Could not get spotify id from uri: ${content.spotify_episode_uri}`,
+          `Could not get spotify id from uri: ${content.spotify_track_uri}`,
         );
         continue;
       }


### PR DESCRIPTION
## Description
Spotify seems to have changed their extended streaming history export format. This PR updates the validation schema to match the new format.
Fixes #452
Solution described in https://github.com/Yooooomi/your_spotify/issues/452#issuecomment-2495558181

### Changes
- Updated `fullPrivacyFileSchema` to match Spotify's new export format:
  - Removed `username` field (no longer provided)
  - Removed `user_agent_decrypted` field (no longer provided)
  - Renamed `ip_addr_decrypted` to `ip_addr` to match new field name

