### PR TITLE
feat: add health endpoint

### DIFF
--- a/apps/server/src/database/queries/meta.ts
+++ b/apps/server/src/database/queries/meta.ts
@@ -35,3 +35,55 @@ export async function setFeatureCompatibilityVersion(version: string) {
   const admin = mongoose.connection.db.admin();
   await admin.command({ setFeatureCompatibilityVersion: version });
 }
+
+export async function getDatabaseHealth(): Promise<{
+  status: "UP" | "DOWN" | "READONLY";
+  details?: {
+    version: string;
+    uptime: number;
+    writable: boolean;
+  };
+  message?: string;
+}> {
+  if (!mongoose.connection.readyState || !mongoose.connection.db) {
+    return { status: "DOWN", message: "Database not connected" };
+  }
+
+  try {
+    const mongoInfos = await getMongoInfos();
+
+    // Fetch server status to get uptime
+    const admin = mongoose.connection.db.admin();
+    const serverStatus = await admin.command({ serverStatus: 1 });
+
+    // Check for fsyncLock using db.currentOp()
+    const currentOp = await admin.command({ currentOp: 1 });
+    const isWriteLocked = currentOp.inprog.some((op: { desc: string, active: boolean }) => op.desc === 'fsyncLockWorker' && op.active);
+
+    if (isWriteLocked) {
+      return {
+        status: "READONLY",
+        details: {
+          version: mongoInfos.version,
+          uptime: serverStatus.uptime || 0,
+          writable: false,
+        },
+        message: "Database is read-only (fsyncLock enabled)",
+      };
+    }
+
+    // If no lock is detected, check if the DB is generally writable
+    return {
+      status: "UP",
+      details: {
+        version: mongoInfos.version,
+        uptime: serverStatus.uptime || 0,
+        writable: true,
+      },
+    };
+
+  } catch (error) {
+    console.error("Error querying database health:", error);
+    return { status: "DOWN", message: "Error querying database health" };
+  }
+}

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -42,7 +42,7 @@ router.get("/health", async (_, res) => {
     const dbHealth = await getDatabaseHealth();
 
     if (dbHealth.status === "DOWN") {
-      res.status(503).send({status: "DB connection error", db_health: dbHealth});
+      res.status(503).send({status: "error", db_health: dbHealth});
     } else if (dbHealth.status === "READONLY") {
       res.status(503).send({status: "warning", db_health: dbHealth});
     } else {


### PR DESCRIPTION
Checks DB connection & lock status.

I'm largely unfamiliar with TS (and Mongo for that matter lol), but this change has achieved my goal and seems to function well. Hopefully it's suitable. Let me know what you think.

## Responses

Connected and unlocked:

```json
{
    "status": "ok",
    "db_health": {
        "status": "UP",
        "details": {
            "version": "6.0.19",
            "uptime": 6843,
            "writable": true
        }
    }
}
```

Connected and locked:

```json
{
    "status": "warning",
    "db_health": {
        "status": "READONLY",
        "details": {
            "version": "6.0.19",
            "uptime": 7244,
            "writable": false
        },
        "message": "Database is read-only (fsyncLock enabled)"
    }
}
```

Disconnected:

```json
{
    "status": "error",
    "db_health": {
        "status": "DOWN",
        "message": "Error querying database health"
    }
}
```