### PR TITLE
fix(ci): set opencontainer labels of docker images

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        
+      - name: Docker metadata
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: yooooomi/your_spotify # required dummy value, will not be used
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -40,6 +46,7 @@ jobs:
           file: ./Dockerfile.client.production
           platforms: linux/amd64,linux/arm64
           push: true
+          labels: ${{ steps.docker-meta.outputs.labels }}
           tags: |
             yooooomi/your_spotify_client:nightly
             yooooomi/your_spotify_client:${{ github.sha }}
@@ -51,6 +58,7 @@ jobs:
           file: ./Dockerfile.server.production
           platforms: linux/amd64,linux/arm64
           push: true
+          labels: ${{ steps.docker-meta.outputs.labels }}
           tags: |
             yooooomi/your_spotify_server:nightly
             yooooomi/your_spotify_server:${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Docker metadata
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: yooooomi/your_spotify # required dummy value, will not be used
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -39,6 +45,7 @@ jobs:
           file: ./Dockerfile.client.production
           platforms: linux/amd64,linux/arm64
           push: true
+          labels: ${{ steps.docker-meta.outputs.labels }}
           tags: |
             yooooomi/your_spotify_client:latest
             yooooomi/your_spotify_client:${{ steps.tag.outputs.tag }}
@@ -50,6 +57,7 @@ jobs:
           file: ./Dockerfile.server.production
           platforms: linux/amd64,linux/arm64
           push: true
+          labels: ${{ steps.docker-meta.outputs.labels }}
           tags: |
             yooooomi/your_spotify_server:latest
             yooooomi/your_spotify_server:${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
This PR sets some OpenContainer labels of the docker images published to DockerHub.

I implemented this as I want Renovate to [parse Changelogs correctly](https://docs.renovatebot.com/modules/datasource/docker/#table-of-values). It infers the GitHub repo using the standardized label `org.opencontainers.image.source`.
Since it wasn't set yet, Renovate failed to fetch said changelog.

This solution (should) not only add this `image.source` label but also [other best-practice labels](https://github.com/marketplace/actions/docker-metadata-action#bake-definition)