### PR TITLE
fix(client): zoom cover images instead of stretching

### DIFF
--- a/apps/client/src/components/IdealImage/IdealImage.tsx
+++ b/apps/client/src/components/IdealImage/IdealImage.tsx
@@ -1,5 +1,6 @@
 import { getAtLeastImage } from "../../services/tools";
 import { HTMLProps, SpotifyImage } from "../../services/types";
+import s from "./index.module.css";
 
 interface IdealImageProps extends HTMLProps<"img"> {
   images: SpotifyImage[];
@@ -13,6 +14,7 @@ export default function IdealImage({
 }: IdealImageProps) {
   return (
     <img
+      className={s.image}
       alt="cover"
       src={getAtLeastImage(images, size)}
       height={size}

--- a/apps/client/src/components/IdealImage/index.module.css
+++ b/apps/client/src/components/IdealImage/index.module.css
@@ -1,0 +1,3 @@
+.image {
+  object-fit: cover;
+}

--- a/apps/client/src/components/PlayButton/index.module.css
+++ b/apps/client/src/components/PlayButton/index.module.css
@@ -15,6 +15,7 @@
   left: 0px;
   height: 48px;
   width: 48px;
+  object-fit: cover;
 }
 
 .icon {

--- a/apps/client/src/scenes/AlbumStats/index.module.css
+++ b/apps/client/src/scenes/AlbumStats/index.module.css
@@ -3,6 +3,11 @@
   width: var(--header-image-size);
   border-radius: var(--radius);
   margin-right: 16px;
+  object-fit: cover;
+}
+
+.cardimg {
+  object-fit: cover;
 }
 
 .content {

--- a/apps/client/src/scenes/ArtistStats/FirstAndLast/index.module.css
+++ b/apps/client/src/scenes/ArtistStats/FirstAndLast/index.module.css
@@ -2,6 +2,7 @@
   height: 48px;
   width: 48px;
   border-radius: 6px;
+  object-fit: cover;
 }
 
 .item {

--- a/apps/client/src/scenes/ArtistStats/index.module.css
+++ b/apps/client/src/scenes/ArtistStats/index.module.css
@@ -37,6 +37,7 @@
   height: 48px;
   width: 48px;
   border-radius: 6px;
+  /*object-fit: cover;*/
 }
 
 .songslistened {

--- a/apps/client/src/scenes/Tops/Albums/Album/index.module.css
+++ b/apps/client/src/scenes/Tops/Albums/Album/index.module.css
@@ -4,6 +4,7 @@
 
 .cover {
   border-radius: var(--radius);
+  object-fit: cover;
 }
 
 .names > :first-child {

--- a/apps/client/src/scenes/TrackStats/index.module.css
+++ b/apps/client/src/scenes/TrackStats/index.module.css
@@ -3,6 +3,7 @@
   width: var(--header-image-size);
   border-radius: var(--radius);
   margin-right: 16px;
+  object-fit: cover;
 }
 
 .content {


### PR DESCRIPTION
For videos, the spotify api can return song covers that are not square, the default behavior was to distort the images.
We could also get the cover on the audio only version of the song, but this may require an additional api call.