### PR TITLE
Fix slow Docker container termination

### DIFF
--- a/apps/client/scripts/build/10-build_react.sh
+++ b/apps/client/scripts/build/10-build_react.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 echo "NODE_ENV is '$NODE_ENV'"
 

--- a/apps/client/scripts/run/run.sh
+++ b/apps/client/scripts/run/run.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
+set -e
 
 # Setup API variable
 source /app/apps/client/scripts/run/variables.sh
 
 # Host the static website
-source /app/apps/client/scripts/run/serve.sh
+exec /app/apps/client/scripts/run/serve.sh

--- a/apps/client/scripts/run/run_dev.sh
+++ b/apps/client/scripts/run/run_dev.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
+set -e
 
 source /app/apps/client/scripts/run/variables.sh
 
-cd /app/apps/client && yarn start
+cd /app/apps/client
+exec yarn start

--- a/apps/client/scripts/run/serve.sh
+++ b/apps/client/scripts/run/serve.sh
@@ -4,4 +4,4 @@
 # -l 0.0.0.0 means that it's hosted on all the interfaces
 # build/ is the output of the package built at build-time
 
-serve -c /app/apps/client/scripts/run/serve.json -s -l tcp://0.0.0.0:3000 /app/apps/client/build/
+exec serve -c /app/apps/client/scripts/run/serve.json -s -l tcp://0.0.0.0:3000 /app/apps/client/build/

--- a/apps/client/scripts/run/variables.sh
+++ b/apps/client/scripts/run/variables.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [[ "$NODE_ENV" == "development" ]]
 then

--- a/apps/server/scripts/run/run.sh
+++ b/apps/server/scripts/run/run.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
+set -e
 
 source /app/apps/server/scripts/run/deprecated.sh
 
-cd apps/server && yarn migrate && yarn start
+cd apps/server
+yarn migrate
+exec yarn start

--- a/apps/server/scripts/run/run_dev.sh
+++ b/apps/server/scripts/run/run_dev.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
+set -e
 
 source /app/apps/server/scripts/run/deprecated.sh
 
-cd apps/server && yarn build && yarn migrate && yarn dev
+cd apps/server
+yarn build
+yarn migrate
+exec yarn dev


### PR DESCRIPTION
Hey! This project is a lot of fun, but I've noticed that the Docker containers are slow to terminate. When I stop them, the containers keep running up until Docker decides to kill them. This is due to the shell scripts being run as PID 0, and not passing signals to node.

This PR changes the startup scripts to use `exec`, which replaces the script PID with the command it runs. This means when Docker sends a `SIGTERM`, it will go directly to node, immediately telling it to exit.

I also went ahead and added `set -e` which makes a script exit if a command fails. This removes the need for chaining `&&`.