### PR TITLE
bump to 1.13.0

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@your_spotify/client",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@your_spotify/server",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "scripts": {
     "start": "node lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@your_spotify/root",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "repository": "git@github.com:Yooooomi/your_spotify.git",
   "author": "Timothee <timothee.boussus@gmail.com>",
   "private": true,


### PR DESCRIPTION
The version in the `package.json` files wasn't updated with the 1.13.0 release, and thus the UI still displays the old version.