### PR TITLE
ci: fix client ghcr repo not being pushed to on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
           tags: |
             yooooomi/your_spotify_client:latest
             yooooomi/your_spotify_client:${{ steps.tag.outputs.tag }}
-            ghcr.io/yooooomi/your_spotify_server:latest
-            ghcr.io/yooooomi/your_spotify_server:${{ steps.tag.outputs.tag }}
+            ghcr.io/yooooomi/your_spotify_client:latest
+            ghcr.io/yooooomi/your_spotify_client:${{ steps.tag.outputs.tag }}
 
       - name: Build and push server release
         uses: docker/build-push-action@v5


### PR DESCRIPTION
I'm glad you added ghcr repos in the latest release, but during migration I noticed the client hadn't gotten the release tag pushed. I took a look at the CI script and there's a typo causing the client to be pushed to to the server ghcr repo. This PR fixes that.

Related to #510