### PR TITLE
feat: Add preset interval for today in intervals.ts

### DIFF
--- a/apps/client/src/services/intervals.ts
+++ b/apps/client/src/services/intervals.ts
@@ -10,7 +10,7 @@ import { Timesplit } from "./types";
 import { getFirstListenedAt } from "./user";
 
 export const today = new Date();
-today.setHours(0);
+today.setHours(0, 0, 0, 0);
 export const lastDay = new Date();
 lastDay.setDate(lastDay.getDate() - 1);
 export const lastWeek = fresh(new Date(), true);

--- a/apps/client/src/services/intervals.ts
+++ b/apps/client/src/services/intervals.ts
@@ -9,6 +9,8 @@ import { getMinOfArray } from "./tools";
 import { Timesplit } from "./types";
 import { getFirstListenedAt } from "./user";
 
+export const today = new Date();
+today.setHours(0);
 export const lastDay = new Date();
 lastDay.setDate(lastDay.getDate() - 1);
 export const lastWeek = fresh(new Date(), true);
@@ -60,6 +62,12 @@ export type RawIntervalDetail = {
 };
 
 export const presetIntervals = [
+  {
+    type: "preset",
+    name: "Today",
+    unit: "day",
+    interval: { timesplit: Timesplit.hour, start: today, end: now },
+  },
   {
     type: "preset",
     name: "Last day",


### PR DESCRIPTION
This PR adds a predefined "Today" interval to intervals.ts, allowing users to filter and analyze their Spotify activity specifically for the current calendar day, rather than just the last 24 hours. This improves usability for daily insights.