### PR TITLE
Fix: collaborative routes: normalize otherIds query param

### DIFF
--- a/apps/server/src/routes/spotify.ts
+++ b/apps/server/src/routes/spotify.ts
@@ -245,17 +245,27 @@ const collaborativeSchema = intervalPerSchema.merge(
   }),
 );
 
+export function normalizeOtherIdsQuery(query: any) {
+  if (query['otherIds[]']) {
+    query.otherIds = Array.isArray(query['otherIds[]'])
+      ? query['otherIds[]']
+      : [query['otherIds[]']];
+    delete query['otherIds[]'];
+  }
+  return query;
+}
+
 router.get(
   "/collaborative/top/songs",
   logged,
   affinityAllowed,
   async (req, res) => {
+    const normalizedQuery = normalizeOtherIdsQuery(req.query);
     const { user } = req as LoggedRequest;
     const { start, end, otherIds, mode } = validate(
-      req.query,
+      normalizedQuery,
       collaborativeSchema,
     );
-
     const result = await getCollaborativeBestSongs(
       [user._id.toString(), ...otherIds.filter(e => e.length > 0)],
       start,
@@ -272,9 +282,10 @@ router.get(
   logged,
   affinityAllowed,
   async (req, res) => {
+    const normalizedQuery = normalizeOtherIdsQuery(req.query);
     const { user } = req as LoggedRequest;
     const { start, end, otherIds, mode } = validate(
-      req.query,
+      normalizedQuery,
       collaborativeSchema,
     );
 
@@ -293,9 +304,10 @@ router.get(
   logged,
   affinityAllowed,
   async (req, res) => {
+    const normalizedQuery = normalizeOtherIdsQuery(req.query);
     const { user } = req as LoggedRequest;
     const { start, end, otherIds, mode } = validate(
-      req.query,
+      normalizedQuery,
       collaborativeSchema,
     );
 


### PR DESCRIPTION
This update introduces a helper function normalizeOtherIdsQuery to handle query parameters where otherIds[] may be passed as either a single value or an array. This ensures consistent handling before validation and prevents potential issues when interacting with the collaborativeSchema.
This should fix #524.

This normalization has been applied to the following routes:

    /collaborative/top/songs

    /collaborative/top/artists

    /collaborative/top/genres

📝 Note:
This is my first time working on a large-scale project like this, and I'm not yet very familiar with TypeScript or Node.js. Feedback and suggestions for improvement are very welcome!