### PR TITLE
feat: include local timestamp in logger output

### DIFF
--- a/apps/server/src/tools/logger.ts
+++ b/apps/server/src/tools/logger.ts
@@ -14,11 +14,15 @@ export function LogLevelAccepts(wantedLogLevel: LogLevel) {
 
 export const logger = {
   debug: (...args: any) =>
-    LogLevelToNumber[logLevel] <= 0 && console.log("[debug] ", ...args),
+    LogLevelToNumber[logLevel] <= 0 &&
+    console.log(`[debug] [${new Date().toLocaleString()}]`, ...args),
   info: (...args: any) =>
-    LogLevelToNumber[logLevel] <= 1 && console.log("[info] ", ...args),
+    LogLevelToNumber[logLevel] <= 1 &&
+    console.log(`[info] [${new Date().toLocaleString()}]`, ...args),
   warn: (...args: any) =>
-    LogLevelToNumber[logLevel] <= 2 && console.warn("[warn] ", ...args),
+    LogLevelToNumber[logLevel] <= 2 &&
+    console.warn(`[warn] [${new Date().toLocaleString()}]`, ...args),
   error: (...args: any) =>
-    LogLevelToNumber[logLevel] <= 3 && console.error("[error] ", ...args),
+    LogLevelToNumber[logLevel] <= 3 &&
+    console.error(`[error] [${new Date().toLocaleString()}]`, ...args),
 };


### PR DESCRIPTION
This change adds a local timestamp to each log entry, improving the debugging experience by making it easier to identify time gaps between log messages. While it might not be necessary in every situation, I’ve encountered multiple cases where the absence of a timestamp made troubleshooting more difficult.