### PR TITLE
Format hrs:mins durations nicely

### DIFF
--- a/apps/client/src/components/History/Track/Track.tsx
+++ b/apps/client/src/components/History/Track/Track.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useMemo } from "react";
 import clsx from "clsx";
-import { msToMinutesAndSeconds } from "../../../services/stats";
+import { msToDuration } from "../../../services/stats";
 import { Album, Artist, Track as TrackType } from "../../../services/types";
 import InlineArtist from "../../InlineArtist";
 import Text from "../../Text";
@@ -59,7 +59,7 @@ export default function Track({
       {
         ...trackGrid.duration,
         node: !isMobile && (
-          <Text>{msToMinutesAndSeconds(track.duration_ms)}</Text>
+          <Text>{msToDuration(track.duration_ms)}</Text>
         ),
       },
       {

--- a/apps/client/src/scenes/AlbumStats/AlbumStats.tsx
+++ b/apps/client/src/scenes/AlbumStats/AlbumStats.tsx
@@ -9,7 +9,7 @@ import InlineTrack from "../../components/InlineTrack";
 import TitleCard from "../../components/TitleCard";
 import Text from "../../components/Text";
 import ImageTwoLines from "../../components/ImageTwoLines";
-import { msToMinutesAndSeconds } from "../../services/stats";
+import { msToDuration } from "../../services/stats";
 import s from "./index.module.css";
 import AlbumRank from "./AlbumRank";
 
@@ -72,7 +72,7 @@ export default function AlbumStats({ stats }: AlbumStatsProps) {
                 ))}
                 <ImageTwoLines
                   image={<TimelapseOutlined color="primary" fontSize="large" />}
-                  first={`${msToMinutesAndSeconds(
+                  first={`${msToDuration(
                     stats.tracks.reduce(
                       (acc, { track }) => track.duration_ms + acc,
                       0,

--- a/apps/client/src/scenes/Tops/Albums/Album/Album.tsx
+++ b/apps/client/src/scenes/Tops/Albums/Album/Album.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useMemo } from 'react';
 import s from './index.module.css';
-import { msToMinutesAndSeconds } from '../../../../services/stats';
+import { msToDuration } from '../../../../services/stats';
 import { Artist, Album as AlbumType } from '../../../../services/types';
 import InlineArtist from '../../../../components/InlineArtist';
 import Text from '../../../../components/Text';
@@ -81,7 +81,7 @@ export default function Album({
         ...albumGrid.total,
         node: (
           <Text className="center">
-            {msToMinutesAndSeconds(duration)}
+            {msToDuration(duration)}
             {!isMobile && (
               <>
                 {" "}

--- a/apps/client/src/scenes/Tops/Artists/Artist/Artist.tsx
+++ b/apps/client/src/scenes/Tops/Artists/Artist/Artist.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { msToMinutesAndSeconds } from "../../../../services/stats";
+import { msToDuration } from "../../../../services/stats";
 import { Artist as ArtistType } from "../../../../services/types";
 import InlineArtist from "../../../../components/InlineArtist";
 import Text from "../../../../components/Text";
@@ -78,7 +78,7 @@ export default function Artist({
         ...artistGrid.total,
         node: (
           <Text className="center">
-            {msToMinutesAndSeconds(duration)}
+            {msToDuration(duration)}
             {!isMobile && (
               <>
                 {" "}

--- a/apps/client/src/scenes/Tops/Songs/Track/Track.tsx
+++ b/apps/client/src/scenes/Tops/Songs/Track/Track.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useMemo } from "react";
 import clsx from "clsx";
-import { msToMinutesAndSeconds } from "../../../../services/stats";
+import { msToDuration } from "../../../../services/stats";
 import { Artist, Album, Track as TrackType } from "../../../../services/types";
 import InlineArtist from "../../../../components/InlineArtist";
 import InlineTrack from "../../../../components/InlineTrack";
@@ -71,7 +71,7 @@ export default function Track(props: TrackProps) {
       {
         ...trackGrid.duration,
         node: !isMobile && (
-          <Text element="div">{msToMinutesAndSeconds(track.duration_ms)}</Text>
+          <Text element="div">{msToDuration(track.duration_ms)}</Text>
         ),
       },
       {
@@ -92,7 +92,7 @@ export default function Track(props: TrackProps) {
         ...trackGrid.total,
         node: (
           <Text element="div" className="center">
-            {msToMinutesAndSeconds(duration)}
+            {msToDuration(duration)}
             {!isMobile && (
               <>
                 {" "}

--- a/apps/client/src/services/stats.ts
+++ b/apps/client/src/services/stats.ts
@@ -300,10 +300,26 @@ export const formatXAxisDateTooltip: TitleFormatter<
 > = (_, payload) => formatDateWithPrecisionToString(payload.dateWithPrecision);
 
 export const msToMinutes = (ms: number) => Math.floor(ms / 1000 / 60);
-export const msToMinutesAndSeconds = (ms: number) =>
-  `${msToMinutes(ms)}:${pad(
-    Math.floor((ms - msToMinutes(ms) * 1000 * 60) / 1000),
-  )}`;
+
+export const msToDuration = (ms: number) => {
+  if (ms === 0) {
+    return "0s";
+  }
+
+  const seconds = Math.floor((ms / 1000) % 60);
+  const minutes = Math.floor((ms / (1000 * 60)) % 60);
+  const hours = Math.floor((ms / (1000 * 60 * 60)) % 24);
+  const days = Math.floor(ms / (1000 * 60 * 60 * 24));
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0) parts.push(`${seconds}s`);
+
+  return parts.join(' ');
+};
+  
 
 export const getLastPeriod = (start: Date, end: Date) => {
   const diff = end.getTime() - start.getTime();


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/06f3d14f-98da-4d9d-a1ce-8fa23ff42c76)
After:
![image](https://github.com/user-attachments/assets/49a7025e-6fc0-4b96-af44-db6d1405d29f)

The percentage now wraps to the next line. Imo that's fine though as the line height is as large as it is now anyway due to the thumbnail.