### PR TITLE
fix: hide left over duration column header

### DIFF
--- a/apps/client/src/scenes/Tops/Artists/Artist/ArtistHeader.tsx
+++ b/apps/client/src/scenes/Tops/Artists/Artist/ArtistHeader.tsx
@@ -24,7 +24,11 @@ export default function ArtistHeader() {
     },
     {
       ...artistGrid.total,
-      node: <Text className="center" size='normal'>Total</Text>,
+      node: !isMobile && (
+        <Text className="center" size="normal">
+          Total
+        </Text>
+      ),
     },
   ];
 


### PR DESCRIPTION
The recent commit 686ca98f4648 removed duration as a column for isMobile but the header is still showing.


<img width="300" alt="image" src="https://github.com/user-attachments/assets/cddd2934-9115-4032-8b02-7b1804706ae0" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/011e2cb9-e06d-4241-8dad-edc39b3f90b0" />
