### PR TITLE
Fix: Protocol mismatch in variables.js when using HTTPS reverse proxy

### DIFF
--- a/apps/client/scripts/run/variables.sh
+++ b/apps/client/scripts/run/variables.sh
@@ -19,7 +19,12 @@ then
 fi
 
 echo "Setting API Endpoint to '$API_ENDPOINT'"
-sed -i "s;__API_ENDPOINT__;$API_ENDPOINT;g" "$VAR_PATH/variables.js"
+# Escape '&' because sed replacement treats it as the full match.
+API_ENDPOINT_ESCAPED=$(printf '%s' "$API_ENDPOINT" | sed 's/[&]/\\&/g')
+
+# Replace the full assignment so it works whether variables.js contains the placeholder
+# or a previously hardcoded endpoint.
+sed -i "s;window.API_ENDPOINT = .*;window.API_ENDPOINT = '$API_ENDPOINT_ESCAPED';g" "$VAR_PATH/variables.js"
 
 # Editing meta image urls
 sed -i "s;image\" content=\"\(.[^\"]*\);image\" content=\"$API_ENDPOINT/static/your_spotify_1200.png;g" "$VAR_PATH/index.html"


### PR DESCRIPTION
I encountered an issue while running your_spotify behind an HTTPS reverse proxy. The variables.js file was forcing requests over HTTP instead of preserving the HTTPS protocol. This caused the browser to block the requests due to "Mixed Content" errors, breaking the site.

I have submitted a fix for this, but I am open to alternative implementations if you prefer a different approach to support HTTPS API calls. Thanks!