### PR TITLE
Feature: merge songs by isrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,8 @@ docker-compose-personal.yml
 client/public/index.html
 client/public/variables.js
 db_data
+
+# ISRC merge report files
+isrc-merge-report.md
+isrc-dry-run-report.md
+merge-tracks-by-isrc-*.md

--- a/apps/client/src/scenes/LongestSessions/LongestSession/LongestSession.tsx
+++ b/apps/client/src/scenes/LongestSessions/LongestSession/LongestSession.tsx
@@ -12,17 +12,19 @@ import {
   intervalToHoursAndMinutes,
 } from "../../../services/date";
 import { useLoadArtists } from "../../../services/hooks/artist";
-import { Track, TrackInfo } from "../../../services/types";
+import { Album, Track, TrackInfo } from "../../../services/types";
 import s from "./index.module.css";
 
 interface LongestSessionProps {
   tracks: TrackInfo[];
   fullTracks: Record<string, Track>;
+  fullAlbums: Record<string, Album>;
 }
 
 export default function LongestSession({
   tracks,
   fullTracks,
+  fullAlbums,
 }: LongestSessionProps) {
   const artistIds = [
       ...tracks.reduce((acc, track) => {
@@ -67,6 +69,7 @@ export default function LongestSession({
         {tracks.map((track, index) => {
           const artist = artists[track.primaryArtistId];
           const fullTrack = fullTracks[track.id];
+          const album = fullAlbums[track.albumId];
           return (
             <div key={track._id} className={clsx("play-button-holder", s.line)}>
               <Text size="normal">#{index + 1}</Text>
@@ -74,7 +77,9 @@ export default function LongestSession({
                 image={
                   <PlayButton
                     id={track.id}
-                    covers={artists[track.primaryArtistId]?.images ?? []}
+                    covers={
+                      album?.images ?? artists[track.primaryArtistId]?.images ?? []
+                    }
                   />
                 }
                 first={fullTrack ? <InlineTrack size='normal' track={fullTrack} /> : null}

--- a/apps/client/src/scenes/LongestSessions/LongestSessions.tsx
+++ b/apps/client/src/scenes/LongestSessions/LongestSessions.tsx
@@ -40,6 +40,7 @@ export default function LongestSessions() {
                 key={r.distanceToLast.distance.map(e => e.info._id).join(",")}
                 tracks={r.distanceToLast.distance.map(e => e.info)}
                 fullTracks={r.full_tracks}
+                fullAlbums={r.full_albums}
               />
             ))}
           </TitleCard>

--- a/apps/client/src/scenes/Tops/Albums/Albums.tsx
+++ b/apps/client/src/scenes/Tops/Albums/Albums.tsx
@@ -37,7 +37,15 @@ export default function Albums() {
                 <Album
                   key={item.album.id}
                   rank={rank + 1}
-                  artists={[item.artist]}
+                  artists={
+                    item.album_artists.length > 0 &&
+                    !(
+                      item.album_artists.length === 1 &&
+                      item.album_artists[0]?.name === "Various Artists"
+                    )
+                      ? item.album_artists
+                      : [item.artist]
+                  }
                   album={item.album}
                   count={item.count}
                   totalCount={item.total_count}

--- a/apps/client/src/scenes/Tops/Songs/Songs.tsx
+++ b/apps/client/src/scenes/Tops/Songs/Songs.tsx
@@ -71,7 +71,11 @@ export default function Songs() {
                           rank={index + 1}
                           track={item.track}
                           album={item.album}
-                          artists={[item.artist]}
+                          artists={
+                            item.track_artists.length > 0
+                              ? item.track_artists
+                              : [item.artist]
+                          }
                           count={item.count}
                           totalCount={item.total_count}
                           duration={item.duration_ms}

--- a/apps/client/src/scenes/TrackStats/TrackStats.tsx
+++ b/apps/client/src/scenes/TrackStats/TrackStats.tsx
@@ -24,6 +24,9 @@ export default function TrackStats({ trackId, stats }: TrackStatsProps) {
   }
 
   const [bestPeriod, secondBestPeriod] = stats.bestPeriod;
+  const albumById = Object.fromEntries(
+    stats.listenedOn.map(item => [item.album.id, item.album]),
+  );
 
   return (
     <div>
@@ -68,6 +71,19 @@ export default function TrackStats({ trackId, stats }: TrackStatsProps) {
                   first={<InlineAlbum album={stats.album} size='normal' />}
                   second="Album"
                 />
+              </TitleCard>
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <TitleCard title="Listened on">
+                {stats.listenedOn.map(({ album, count }) => (
+                  <ImageTwoLines
+                    key={album.id}
+                    className={s.recentitem}
+                    image={<IdealImage images={album.images} size={48} />}
+                    first={<InlineAlbum album={album} size='normal' />}
+                    second={`${count} ${count === 1 ? "time" : "times"}`}
+                  />
+                ))}
               </TitleCard>
             </Grid>
             <Grid size={{ xs: 12 }}>
@@ -121,17 +137,20 @@ export default function TrackStats({ trackId, stats }: TrackStatsProps) {
           </Grid>
           <Grid size={{ lg: 6, xs: 12 }}>
             <TitleCard title="Recently played on">
-              {stats.recentHistory.map(info => (
-                <ImageTwoLines
-                  className={s.recentitem}
-                  key={info.id}
-                  image={<IdealImage images={stats.album.images} size={48} />}
-                  first={stats.track.name}
-                  second={DateFormatter.toMinuteHourDayMonthYear(
-                    new Date(info.played_at),
-                  )}
-                />
-              ))}
+              {stats.recentHistory.map(info => {
+                const album = albumById[info.albumId] ?? stats.album;
+                return (
+                  <ImageTwoLines
+                    className={s.recentitem}
+                    key={info._id}
+                    image={<IdealImage images={album.images} size={48} />}
+                    first={<InlineAlbum album={album} size='normal' />}
+                    second={DateFormatter.toMinuteHourDayMonthYear(
+                      new Date(info.played_at),
+                    )}
+                  />
+                );
+              })}
             </TitleCard>
           </Grid>
         </Grid>

--- a/apps/client/src/scenes/TrackStats/TrackStats.tsx
+++ b/apps/client/src/scenes/TrackStats/TrackStats.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import { CircularProgress, Grid } from "@mui/material";
 import Header from "../../components/Header";
 import TitleCard from "../../components/TitleCard";
@@ -40,7 +41,12 @@ export default function TrackStats({ trackId, stats }: TrackStatsProps) {
           />
         }
         title={stats.track.name}
-        subtitle={<InlineArtist artist={stats.artist} size='normal' />}
+        subtitle={stats.artists.map((artist, index) => (
+          <Fragment key={artist.id}>
+            <InlineArtist artist={artist} size='normal' />
+            {index < stats.artists.length - 1 && ", "}
+          </Fragment>
+        ))}
         hideInterval
       />
       <div className={s.content}>
@@ -60,17 +66,16 @@ export default function TrackStats({ trackId, stats }: TrackStatsProps) {
             alignItems="flex-start"
             spacing={2}>
             <Grid size={{ xs: 12 }}>
-              <TitleCard title="Context" contentClassName={s.context}>
-                <ImageTwoLines
-                  image={<IdealImage images={stats.artist.images} size={48} />}
-                  first={<InlineArtist artist={stats.artist} size='normal' />}
-                  second="Artist"
-                />
-                <ImageTwoLines
-                  image={<IdealImage images={stats.album.images} size={48} />}
-                  first={<InlineAlbum album={stats.album} size='normal' />}
-                  second="Album"
-                />
+              <TitleCard title="Artists">
+                {stats.artists.map((artist, index) => (
+                  <ImageTwoLines
+                    key={artist.id}
+                    className={s.recentitem}
+                    image={<IdealImage images={artist.images} size={48} />}
+                    first={<InlineArtist artist={artist} size='normal' />}
+                    second={index === 0 ? "Main artist" : "Featured artist"}
+                  />
+                ))}
               </TitleCard>
             </Grid>
             <Grid size={{ xs: 12 }}>

--- a/apps/client/src/services/apis/api.ts
+++ b/apps/client/src/services/apis/api.ts
@@ -157,6 +157,10 @@ export type TrackStatsResponse = {
   track: Track;
   artist: Artist;
   album: Album;
+  listenedOn: {
+    count: number;
+    album: Album;
+  }[];
   bestPeriod: {
     _id: DateId;
     count: number;

--- a/apps/client/src/services/apis/api.ts
+++ b/apps/client/src/services/apis/api.ts
@@ -99,37 +99,14 @@ export type ArtistStatsResponse = {
   artist: Artist;
   bestPeriod: {
     _id: DateId;
-    artist: {
-      _id: string;
-      artistInfos: {
-        _id: string;
-        trackId: string;
-        artistId: string;
-      };
-      year: number;
-      month: number;
-      day: number;
-      week: number;
-      hour: number;
-    };
     count: number;
     total: number;
   }[];
   firstLast: {
     first: TrackInfo & {
-      artistInfos: {
-        _id: string;
-        trackId: string;
-        artistId: string;
-      };
       track: TrackWithAlbum;
     };
     last: TrackInfo & {
-      artistInfos: {
-        _id: string;
-        trackId: string;
-        artistId: string;
-      };
       track: TrackWithAlbum;
     };
   };
@@ -155,7 +132,7 @@ export type ArtistStatsResponse = {
 
 export type TrackStatsResponse = {
   track: Track;
-  artist: Artist;
+  artists: Artist[];
   album: Album;
   listenedOn: {
     count: number;
@@ -377,6 +354,7 @@ export const api = {
         album: Album;
         artist: Artist;
         track: Track;
+        track_artists: Artist[];
       }[]
     >("/spotify/top/songs", {
       start,
@@ -409,6 +387,7 @@ export const api = {
         total_duration_ms: number;
         artist: Artist;
         album: Album;
+        album_artists: Artist[];
       }[]
     >("/spotify/top/albums", {
       start,

--- a/apps/client/src/services/apis/api.ts
+++ b/apps/client/src/services/apis/api.ts
@@ -543,6 +543,7 @@ export const api = {
       {
         sessionLength: number;
         full_tracks: Record<string, Track>;
+        full_albums: Record<string, Album>;
         distanceToLast: {
           distance: {
             subtract: number;

--- a/apps/server/ISRC_DEDUPLICATION.md
+++ b/apps/server/ISRC_DEDUPLICATION.md
@@ -1,0 +1,239 @@
+# ISRC Track Deduplication Migration Guide
+
+Spotify can assign multiple track IDs to the same recording when a song appears
+on different releases, such as a standard album, deluxe edition, single, or
+compilation. YourSpotify historically stored listen history by Spotify track ID,
+so those versions could appear as separate songs in stats.
+
+This feature stores Spotify's ISRC (`external_ids.isrc`) on tracks and can merge
+existing duplicates so listens for the same recording point to one canonical
+track.
+
+The migration is optional, but recommended if you already have listening history
+in your database.
+
+## Which Commands Should I Use?
+
+Most self-hosted installations use a copy of `docker-compose-example.yml` and
+start YourSpotify with:
+
+```bash
+docker compose up -d
+```
+
+That compose file uses published Docker images and names the server service
+`server`, so the main commands in this guide use:
+
+```bash
+docker compose exec server ...
+```
+
+If you are developing from this repository with `docker-compose-prod.yml` and
+`docker-compose-personal.yml`, use the alternative commands in the
+[Repository Development Compose](#repository-development-compose) section.
+
+## Before You Start
+
+Make sure:
+
+- Your `yooooomi/your_spotify_server` image has been updated to a version that
+  contains this migration.
+- MongoDB is running and reachable by the server container.
+- `SPOTIFY_PUBLIC` and `SPOTIFY_SECRET` are configured. The migration uses them
+  to fetch missing ISRCs from Spotify.
+- You can run `docker compose` from the directory containing your compose file.
+
+Update the published images and restart the app:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+## Step 1: Back Up MongoDB
+
+Create a backup before applying the migration.
+
+```bash
+docker compose exec mongo \
+  mongodump --archive=/tmp/your_spotify-before-isrc.archive --db your_spotify
+```
+
+Copy the backup from the Mongo container to your host:
+
+```bash
+docker compose cp \
+  mongo:/tmp/your_spotify-before-isrc.archive ./your_spotify-before-isrc.archive
+```
+
+Keep this file until you have verified the migration result.
+
+If your Mongo service has a different name, replace `mongo` with that service
+name.
+
+## Step 2: Run A Dry Run
+
+The migration defaults to dry-run mode. It will inspect the database, fetch
+missing ISRCs from Spotify, choose primary tracks, and write a report without
+changing the database.
+
+```bash
+docker compose exec server \
+  node /app/apps/server/build/index.js --merge-tracks-by-isrc \
+  --report=/tmp/isrc-dry-run-report.md
+```
+
+Copy the report to your host:
+
+```bash
+docker compose cp \
+  server:/tmp/isrc-dry-run-report.md ./isrc-dry-run-report.md
+```
+
+Open `isrc-dry-run-report.md` and check:
+
+- How many duplicate ISRC groups were found.
+- Which track was selected as the primary for each group.
+- Which secondary tracks would be merged.
+- Whether the selected primary tracks look reasonable.
+
+## Step 3: Apply The Migration
+
+Only run apply mode after reviewing the dry-run report.
+
+```bash
+docker compose exec server \
+  node /app/apps/server/build/index.js --merge-tracks-by-isrc \
+  --apply \
+  --report=/tmp/isrc-merge-report.md
+```
+
+Copy the final report to your host:
+
+```bash
+docker compose cp \
+  server:/tmp/isrc-merge-report.md ./isrc-merge-report.md
+```
+
+Keep this report with your backup. It documents the selected primary tracks,
+merged secondary tracks, play counts, updated listen records, and final totals.
+
+## Step 4: Verify The Result
+
+Start or restart the app normally, then check your stats for songs that
+previously appeared as duplicates.
+
+You can also run another dry run:
+
+```bash
+docker compose exec server \
+  node /app/apps/server/build/index.js --merge-tracks-by-isrc \
+  --report=/tmp/isrc-post-migration-audit.md
+```
+
+Copy the audit report:
+
+```bash
+docker compose cp \
+  server:/tmp/isrc-post-migration-audit.md ./isrc-post-migration-audit.md
+```
+
+After a successful migration, this report should show no remaining duplicate
+groups, or fewer groups if Spotify does not provide ISRCs for some tracks. It
+also includes an audit section for tracks already marked with `mergedInto`.
+
+## What The Migration Changes
+
+For each duplicate ISRC group, the migration:
+
+1. Chooses a primary track.
+2. Updates listen records from secondary track IDs to the primary track ID.
+3. Marks secondary track documents with `mergedInto`.
+4. Keeps the primary track's `isrc`.
+5. Removes `isrc` from secondary tracks so the sparse unique index remains valid.
+
+Secondary track documents are not deleted. They are kept for auditability.
+
+## Album And Track Counts
+
+After deduplication, track stats are recording-level while album stats remain
+release-level.
+
+For example, if you listened to the same recording twice on an album and once on
+an EP, the artist page can show that track with 3 listens. The album page for
+the album will still show 2 listens for that track, and the EP can still count
+the remaining listen for that release.
+
+## If You Do Not Run The Migration
+
+The app still works if you upgrade without running this migration.
+
+- Existing history remains unchanged.
+- Existing duplicate tracks remain separate.
+- New tracks store ISRCs when Spotify provides them.
+- New listens can deduplicate against tracks that already have an ISRC.
+- Tracks without ISRC keep the old Spotify-ID behavior.
+
+Run the migration when you want to clean up historical duplicates.
+
+## Rollback
+
+The safest rollback is restoring the MongoDB backup created in step 1.
+
+Stop the app services that write to MongoDB, then copy the backup archive into
+the Mongo container:
+
+```bash
+docker compose cp \
+  ./your_spotify-before-isrc.archive mongo:/tmp/your_spotify-before-isrc.archive
+```
+
+Restore it:
+
+```bash
+docker compose exec mongo \
+  mongorestore --drop --archive=/tmp/your_spotify-before-isrc.archive --nsInclude='your_spotify.*'
+```
+
+Then restart the app:
+
+```bash
+docker compose up -d
+```
+
+## Repository Development Compose
+
+If you are running this repository directly with `docker-compose-prod.yml` and
+`docker-compose-personal.yml`, the server service is named `app`. Use this
+compose prefix:
+
+```bash
+docker compose -f docker-compose-prod.yml -f docker-compose-personal.yml
+```
+
+Example dry run:
+
+```bash
+docker compose -f docker-compose-prod.yml -f docker-compose-personal.yml exec app \
+  node /app/apps/server/build/index.js --merge-tracks-by-isrc \
+  --report=/tmp/isrc-dry-run-report.md
+```
+
+Example apply:
+
+```bash
+docker compose -f docker-compose-prod.yml -f docker-compose-personal.yml exec app \
+  node /app/apps/server/build/index.js --merge-tracks-by-isrc \
+  --apply \
+  --report=/tmp/isrc-merge-report.md
+```
+
+## Local Development Without Docker
+
+If you are not using Docker and have dependencies installed locally:
+
+```bash
+cd apps/server
+pnpm run merge-tracks-by-isrc -- --report=/tmp/isrc-dry-run-report.md
+pnpm run merge-tracks-by-isrc -- --apply --report=/tmp/isrc-merge-report.md
+```

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 - [Prometheus](#prometheus)
+- [Operations](#operations)
 - [API](#api)
   - [Authentication](#authentication)
     - [OAuth](#oauth)
@@ -49,6 +50,11 @@ scrape_configs:
     static_configs:
       - targets: ["example.com:443"]
 ```
+
+## Operations
+
+- [ISRC Track Deduplication](./ISRC_DEDUPLICATION.md): run the manual migration
+  for merging duplicate Spotify track IDs that represent the same recording.
 
 ## API
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "dev": "rsbuild dev",
     "migrate": "node ./build/index.js --migrate",
+    "merge-tracks-by-isrc": "ts-node src/migrations/run.ts",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint --fix . --ext .js,.jsx,.ts,.tsx"
   },

--- a/apps/server/src/database/queries/album.ts
+++ b/apps/server/src/database/queries/album.ts
@@ -8,38 +8,12 @@ export const searchAlbum = (str: string) =>
   AlbumModel.find({ name: { $regex: new RegExp(str, "i") } })
     .populate("full_artists");
 
-export const getAlbumInfos = (albumId: string) => [
-  {
-    $lookup: {
-      from: "tracks",
-      let: { targetId: "$id" },
-      pipeline: [
-        {
-          $match: {
-            $expr: {
-              $and: [
-                { $eq: ["$album", albumId] },
-                { $eq: ["$id", "$$targetId"] },
-              ],
-            },
-          },
-        },
-        { $project: { trackId: "$id", albumId: "$album" } },
-      ],
-      as: "albumInfos",
-    },
-  },
-  { $match: { "albumInfos.albumId": { $exists: true } } },
-  { $unwind: "$albumInfos" },
-];
-
 export const getFirstAndLastListenedAlbum = async (
   user: User,
   albumId: string,
 ) => {
   const res = await InfosModel.aggregate([
     { $match: { owner: user._id, albumId: albumId } },
-    ...getAlbumInfos(albumId),
     { $sort: { played_at: 1 } },
     {
       $group: {
@@ -53,7 +27,7 @@ export const getFirstAndLastListenedAlbum = async (
         {
           $lookup: {
             from: "tracks",
-            localField: `${e}.albumInfos.trackId`,
+            localField: `${e}.id`,
             foreignField: "id",
             as: `${e}.track`,
           },
@@ -68,7 +42,6 @@ export const getFirstAndLastListenedAlbum = async (
 export const getAlbumSongs = async (user: User, albumId: string) => {
   const res = await InfosModel.aggregate([
     { $match: { owner: user._id, albumId: albumId } },
-    ...getAlbumInfos(albumId),
     { $group: { _id: "$id", count: { $sum: 1 } } },
     { $sort: { count: -1 } },
     {

--- a/apps/server/src/database/queries/artist.ts
+++ b/apps/server/src/database/queries/artist.ts
@@ -170,16 +170,8 @@ export const getMostListenedAlbumOfArtist = async (
   const res = await InfosModel.aggregate([
     { $match: { owner: user._id, primaryArtistId: artistId } },
     {
-      $lookup: {
-        from: "tracks",
-        localField: "id",
-        foreignField: "id",
-        as: "track",
-      },
-    },
-    {
       $group: {
-        _id: "$track.album",
+        _id: "$albumId",
         count: { $sum: 1 },
       },
     },

--- a/apps/server/src/database/queries/stats.ts
+++ b/apps/server/src/database/queries/stats.ts
@@ -550,6 +550,22 @@ export const getBest = (
     { $unwind: "$album" },
     { $lookup: lightArtistLookupPipeline("primaryArtistId", false) },
     { $unwind: "$artist" },
+    {
+      $lookup: {
+        from: "artists",
+        localField: "track.artists",
+        foreignField: "id",
+        as: "track_artists",
+      },
+    },
+    {
+      $lookup: {
+        from: "artists",
+        localField: "album.artists",
+        foreignField: "id",
+        as: "album_artists",
+      },
+    },
   ]);
 
 export const getBestOfHour = async (

--- a/apps/server/src/database/queries/stats.ts
+++ b/apps/server/src/database/queries/stats.ts
@@ -230,22 +230,13 @@ export const albumDateRatio = async (
     {
       $project: {
         ...getGroupByDateProjection(user.settings.timezone),
-        id: 1,
+        albumId: 1,
       },
     },
-    {
-      $lookup: {
-        from: "tracks",
-        localField: "id",
-        foreignField: "id",
-        as: "track",
-      },
-    },
-    { $unwind: "$track" },
     {
       $lookup: {
         from: "albums",
-        localField: "track.album",
+        localField: "albumId",
         foreignField: "id",
         as: "album",
       },
@@ -288,25 +279,16 @@ export const featRatio = async (
     {
       $project: {
         ...getGroupByDateProjection(user.settings.timezone),
-        id: 1,
+        artistCount: { $size: { $ifNull: ["$artistIds", []] } },
       },
     },
-    {
-      $lookup: {
-        from: "tracks",
-        localField: "id",
-        foreignField: "id",
-        as: "track",
-      },
-    },
-    { $unwind: "$track" },
     {
       $group: {
         _id: getGroupingByTimeSplit(timeSplit),
         1: {
           $sum: {
             $cond: {
-              if: { $eq: [{ $size: "$track.artists" }, 1] },
+              if: { $eq: ["$artistCount", 1] },
               then: 1,
               else: 0,
             },
@@ -315,7 +297,7 @@ export const featRatio = async (
         2: {
           $sum: {
             $cond: {
-              if: { $eq: [{ $size: "$track.artists" }, 2] },
+              if: { $eq: ["$artistCount", 2] },
               then: 1,
               else: 0,
             },
@@ -324,7 +306,7 @@ export const featRatio = async (
         3: {
           $sum: {
             $cond: {
-              if: { $eq: [{ $size: "$track.artists" }, 3] },
+              if: { $eq: ["$artistCount", 3] },
               then: 1,
               else: 0,
             },
@@ -333,7 +315,7 @@ export const featRatio = async (
         4: {
           $sum: {
             $cond: {
-              if: { $eq: [{ $size: "$track.artists" }, 4] },
+              if: { $eq: ["$artistCount", 4] },
               then: 1,
               else: 0,
             },
@@ -342,13 +324,13 @@ export const featRatio = async (
         5: {
           $sum: {
             $cond: {
-              if: { $eq: [{ $size: "$track.artists" }, 5] },
+              if: { $eq: ["$artistCount", 5] },
               then: 1,
               else: 0,
             },
           },
         },
-        totalPeople: { $sum: { $size: "$track.artists" } },
+        totalPeople: { $sum: "$artistCount" },
         count: { $sum: 1 },
       },
     },
@@ -449,24 +431,19 @@ export const getBestArtistsPer = async (
   const res = await InfosModel.aggregate([
     ...basicMatch(user._id, start, end),
     {
-      $project: { ...getGroupByDateProjection(user.settings.timezone), id: 1 },
-    },
-    {
-      $lookup: {
-        from: "tracks",
-        localField: "id",
-        foreignField: "id",
-        as: "track",
+      $project: {
+        ...getGroupByDateProjection(user.settings.timezone),
+        durationMs: 1,
+        primaryArtistId: 1,
       },
     },
-    { $unwind: "$track" },
     {
       $group: {
         _id: {
           ...getGroupingByTimeSplit(timeSplit),
-          art: { $arrayElemAt: ["$track.artists", 0] },
+          art: "$primaryArtistId",
         },
-        count: { $sum: getTrackSumType(user) },
+        count: { $sum: getTrackSumType(user, "$durationMs") },
       },
     },
     { $sort: { count: -1, "_id.art": 1 } },
@@ -734,11 +711,22 @@ export const getLongestListeningSession = async (
         as: "full_tracks",
       },
     },
+    {
+      $lookup: {
+        from: "albums",
+        localField: "distanceToLast.distance.info.albumId",
+        foreignField: "id",
+        as: "full_albums",
+      },
+    },
   ]);
 
   longestSessions.forEach(longestSession => {
     longestSession.full_tracks = Object.fromEntries(
       longestSession.full_tracks.map((track: any) => [track.id, track]),
+    );
+    longestSession.full_albums = Object.fromEntries(
+      longestSession.full_albums.map((album: any) => [album.id, album]),
     );
   });
 

--- a/apps/server/src/database/queries/stats.ts
+++ b/apps/server/src/database/queries/stats.ts
@@ -565,7 +565,11 @@ export const getBest = (
     },
     { $lookup: lightTrackLookupPipeline("trackId") },
     { $unwind: "$track" },
-    { $lookup: lightAlbumLookupPipeline("albumId") },
+    {
+      $lookup: lightAlbumLookupPipeline(
+        itemType === ItemType.album ? "albumId" : "track.album",
+      ),
+    },
     { $unwind: "$album" },
     { $lookup: lightArtistLookupPipeline("primaryArtistId", false) },
     { $unwind: "$artist" },

--- a/apps/server/src/database/queries/track.ts
+++ b/apps/server/src/database/queries/track.ts
@@ -64,6 +64,29 @@ export const getTrackRecentHistory = async (user: User, trackId: string) =>
     .limit(10)
     .sort({ played_at: -1 });
 
+export const getTrackListenedAlbums = async (user: User, trackId: string) => {
+  const res = await InfosModel.aggregate([
+    { $match: { owner: user._id, id: trackId } },
+    {
+      $group: {
+        _id: "$albumId",
+        count: { $sum: 1 },
+      },
+    },
+    { $sort: { count: -1, _id: 1 } },
+    {
+      $lookup: {
+        from: "albums",
+        localField: "_id",
+        foreignField: "id",
+        as: "album",
+      },
+    },
+    { $unwind: "$album" },
+  ]);
+  return res;
+};
+
 export const getTrackBySpotifyId = (id: string) => TrackModel.findOne({ id });
 
 export const checkBlacklistConsistency = () =>

--- a/apps/server/src/database/queries/track.ts
+++ b/apps/server/src/database/queries/track.ts
@@ -7,7 +7,10 @@ export const getTracks = (tracksId: string[]) =>
   TrackModel.find({ id: { $in: tracksId } });
 
 export const searchTrack = (str: string) =>
-  TrackModel.find({ name: { $regex: new RegExp(str, "i") } })
+  TrackModel.find({
+    name: { $regex: new RegExp(str, "i") },
+    mergedInto: { $exists: false },
+  })
     .populate("full_album")
     .populate("full_artists");
 

--- a/apps/server/src/database/queries/user.ts
+++ b/apps/server/src/database/queries/user.ts
@@ -247,7 +247,7 @@ export const getSongs = async (
     {
       $lookup: {
         from: "albums",
-        localField: "track.album",
+        localField: "albumId",
         foreignField: "id",
         as: "track.full_album",
       },

--- a/apps/server/src/database/schemas/track.ts
+++ b/apps/server/src/database/schemas/track.ts
@@ -11,7 +11,9 @@ export interface Track {
   external_urls: any;
   href: string;
   id: string;
+  isrc?: string;
   is_local: boolean;
+  mergedInto?: string;
   name: string;
   preview_url: string;
   track_number: number;
@@ -19,9 +21,17 @@ export interface Track {
   uri: string;
 }
 
-export type SpotifyTrack = Omit<Track, "artists" | "album"> & {
+export type SpotifyTrack = Omit<
+  Track,
+  "artists" | "album" | "isrc" | "mergedInto"
+> & {
   artists: SpotifyArtist[];
   album: SpotifyAlbum;
+  external_ids?: {
+    isrc?: string;
+    ean?: string;
+    upc?: string;
+  };
 };
 
 export interface RecentlyPlayedTrack {
@@ -39,7 +49,9 @@ export const TrackSchema = new Schema<Track>(
     external_urls: Object,
     href: String,
     id: { type: String, unique: true },
+    isrc: { type: String, index: true, sparse: true, unique: true },
     is_local: Boolean,
+    mergedInto: String,
     name: String,
     preview_url: String,
     track_number: Number,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,8 +1,11 @@
 import { startServer } from "./bin/www";
+import { runMergeTracksByIsrcCli } from "./migrations/mergeTracksByIsrc";
 import { runMigrations } from "./migrations";
 
 if (process.argv[2] === "--migrate") {
   runMigrations();
+} else if (process.argv[2] === "--merge-tracks-by-isrc") {
+  void runMergeTracksByIsrcCli(process.argv.slice(3));
 } else {
   startServer();
 }

--- a/apps/server/src/migrations/mergeTracksByIsrc.ts
+++ b/apps/server/src/migrations/mergeTracksByIsrc.ts
@@ -1,0 +1,514 @@
+import Axios from "axios";
+import { appendFile, mkdir, writeFile } from "fs/promises";
+import mongoose, { HydratedDocument, Types } from "mongoose";
+import { dirname } from "path";
+import { InfosModel, TrackModel } from "../database/Models";
+import { Track } from "../database/schemas/track";
+import { credentials } from "../tools/oauth/credentials";
+import { chunk } from "../tools/misc";
+
+const DEFAULT_MONGO_ENDPOINT = "mongodb://mongo:27017/your_spotify";
+const UPDATE_BATCH_SIZE = 1000;
+const SPOTIFY_FETCH_BATCH_SIZE = 50;
+
+type TrackDocument = HydratedDocument<Track>;
+
+interface PlayCount {
+	_id: string;
+	count: number;
+}
+
+interface SpotifyCatalogTrack {
+	id: string;
+	external_ids?: {
+		isrc?: string;
+	};
+}
+
+interface MergeTracksByIsrcOptions {
+	dryRun?: boolean;
+	reportPath?: string;
+}
+
+export interface MergeTracksByIsrcSummary {
+	dryRun: boolean;
+	duplicateIsrcs: number;
+	redundantTracks: number;
+	infosUpdated: number;
+	tracksMarkedMerged: number;
+	elapsedMs: number;
+	reportPath: string;
+}
+
+export function getDryRunMode(
+	args = process.argv.slice(2),
+	env = process.env,
+) {
+	if (args.includes("--dry-run") || env.DRY_RUN === "true") {
+		return true;
+	}
+	if (args.includes("--apply") || env.DRY_RUN === "false") {
+		return false;
+	}
+	return true;
+}
+
+export function getReportPath(args = process.argv.slice(2), env = process.env) {
+	const reportArg = args.find((arg) => arg.startsWith("--report="));
+	if (reportArg) {
+		return reportArg.slice("--report=".length);
+	}
+	if (env.MERGE_TRACKS_REPORT_PATH) {
+		return env.MERGE_TRACKS_REPORT_PATH;
+	}
+	const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+	return `/tmp/merge-tracks-by-isrc-${timestamp}.md`;
+}
+
+class MigrationReport {
+	constructor(private readonly path: string) {}
+
+	async init(dryRun: boolean) {
+		await mkdir(dirname(this.path), { recursive: true });
+		await writeFile(
+			this.path,
+			[
+				"# ISRC Track Merge Report",
+				"",
+				`Started: ${new Date().toISOString()}`,
+				`Mode: ${dryRun ? "dry-run" : "apply"}`,
+				"",
+			].join("\n"),
+		);
+	}
+
+	async write(message: string) {
+		await appendFile(this.path, `${message}\n`);
+	}
+
+	async section(title: string) {
+		await this.write(`\n## ${title}\n`);
+	}
+}
+
+function getCreatedAtMs(track: TrackDocument) {
+	const id = track._id;
+	if (id instanceof Types.ObjectId) {
+		return id.getTimestamp().getTime();
+	}
+	return Number.POSITIVE_INFINITY;
+}
+
+function electPrimary(
+	tracks: TrackDocument[],
+	playCountsByTrackId: Map<string, number>,
+) {
+	return [...tracks].sort((a, b) => {
+		const playCountDiff =
+			(playCountsByTrackId.get(b.id) ?? 0) -
+			(playCountsByTrackId.get(a.id) ?? 0);
+		if (playCountDiff !== 0) {
+			return playCountDiff;
+		}
+
+		const createdAtDiff = getCreatedAtMs(a) - getCreatedAtMs(b);
+		if (createdAtDiff !== 0) {
+			return createdAtDiff;
+		}
+
+		return a.id.localeCompare(b.id);
+	})[0];
+}
+
+async function getPlayCounts(trackIds: string[]) {
+	const counts = await InfosModel.aggregate<PlayCount>([
+		{ $match: { id: { $in: trackIds } } },
+		{ $group: { _id: "$id", count: { $sum: 1 } } },
+	]);
+	return new Map(counts.map((item) => [item._id, item.count]));
+}
+
+async function getSpotifyCatalogAccessToken() {
+	const { data } = await Axios.post(
+		"https://accounts.spotify.com/api/token",
+		null,
+		{
+			params: { grant_type: "client_credentials" },
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				Authorization: `Basic ${Buffer.from(
+					`${credentials.spotify.public}:${credentials.spotify.secret}`,
+				).toString("base64")}`,
+			},
+		},
+	);
+
+	return data.access_token as string;
+}
+
+async function fetchSpotifyTracks(
+	trackIds: string[],
+	accessToken: string,
+) {
+	try {
+		const { data } = await Axios.get<{
+			tracks: (SpotifyCatalogTrack | null)[];
+		}>("https://api.spotify.com/v1/tracks", {
+			params: { ids: trackIds.join(",") },
+			headers: { Authorization: `Bearer ${accessToken}` },
+		});
+
+		return data.tracks;
+	} catch {
+		const tracks: (SpotifyCatalogTrack | null)[] = [];
+		for (const trackId of trackIds) {
+			try {
+				const { data } = await Axios.get<SpotifyCatalogTrack>(
+					`https://api.spotify.com/v1/tracks/${encodeURIComponent(trackId)}`,
+					{ headers: { Authorization: `Bearer ${accessToken}` } },
+				);
+				tracks.push(data);
+			} catch {
+				tracks.push(null);
+			}
+		}
+		return tracks;
+	}
+}
+
+async function backfillMissingIsrcs() {
+	const tracksMissingIsrc = await TrackModel.find({
+		mergedInto: { $exists: false },
+		$or: [
+			{ isrc: { $exists: false } },
+			{ isrc: null },
+			{ isrc: "" },
+		],
+	});
+
+	if (tracksMissingIsrc.length === 0) {
+		console.log("Step 2a: no tracks need ISRC backfill");
+		return {
+			tracks: [] as TrackDocument[],
+			backfilledCount: 0,
+		};
+	}
+
+	const accessToken = await getSpotifyCatalogAccessToken();
+
+	console.log(
+		`Step 2a: fetching ISRCs from Spotify for ${tracksMissingIsrc.length} tracks for grouping`,
+	);
+
+	let backfilledCount = 0;
+	let processedCount = 0;
+	for (const trackBatch of chunk(tracksMissingIsrc, SPOTIFY_FETCH_BATCH_SIZE)) {
+		const spotifyTracks = await fetchSpotifyTracks(
+			trackBatch.map((track) => track.id),
+			accessToken,
+		);
+		const isrcByTrackId = new Map(
+			spotifyTracks.flatMap((spotifyTrack) => {
+				const isrc = spotifyTrack?.external_ids?.isrc;
+				return spotifyTrack && isrc ? [[spotifyTrack.id, isrc] as const] : [];
+			}),
+		);
+
+		for (const track of trackBatch) {
+			const isrc = isrcByTrackId.get(track.id);
+			if (!isrc) {
+				continue;
+			}
+			track.isrc = isrc;
+			backfilledCount += 1;
+		}
+
+		processedCount += trackBatch.length;
+		console.log(
+			`Step 2a: checked ${processedCount}/${tracksMissingIsrc.length} tracks, found ${backfilledCount} ISRCs`,
+		);
+	}
+
+	return {
+		tracks: tracksMissingIsrc,
+		backfilledCount,
+	};
+}
+
+async function writeExistingMergeAudit(report: MigrationReport) {
+	const mergedTracks = await TrackModel.find({
+		mergedInto: { $exists: true, $ne: null },
+	}).sort({ mergedInto: 1, id: 1 });
+
+	await report.section("Merged Tracks Audit");
+	if (mergedTracks.length === 0) {
+		await report.write("No tracks are currently marked as merged.");
+		return 0;
+	}
+
+	const primaryIds = [
+		...new Set(
+			mergedTracks
+				.map((track) => track.mergedInto)
+				.filter((id): id is string => Boolean(id)),
+		),
+	];
+	const primaryTracks = await TrackModel.find({ id: { $in: primaryIds } });
+	const primaryById = new Map(primaryTracks.map((track) => [track.id, track]));
+	const mergedByPrimaryId = new Map<string, TrackDocument[]>();
+
+	for (const track of mergedTracks) {
+		if (!track.mergedInto) {
+			continue;
+		}
+		const group = mergedByPrimaryId.get(track.mergedInto) ?? [];
+		group.push(track);
+		mergedByPrimaryId.set(track.mergedInto, group);
+	}
+
+	for (const [primaryId, secondaries] of mergedByPrimaryId) {
+		const primary = primaryById.get(primaryId);
+		await report.write(
+			`### ${primaryId}${primary ? ` | ${primary.name}` : " | missing primary track"}`,
+		);
+		for (const secondary of secondaries) {
+			await report.write(`- ${secondary.id} | ${secondary.name}`);
+		}
+		await report.write("");
+	}
+
+	return mergedTracks.length;
+}
+
+async function writeMergeReportGroup(
+	report: MigrationReport,
+	isrc: string,
+	primary: TrackDocument,
+	secondaries: TrackDocument[],
+	playCountsByTrackId: Map<string, number>,
+) {
+	await report.write(`### ISRC ${isrc}`);
+	await report.write(
+		`Primary: ${primary.id} | ${primary.name} | ${
+			playCountsByTrackId.get(primary.id) ?? 0
+		} plays`,
+	);
+	await report.write("Secondaries:");
+	for (const secondary of secondaries) {
+		await report.write(
+			`- ${secondary.id} | ${secondary.name} | ${
+				playCountsByTrackId.get(secondary.id) ?? 0
+			} plays`,
+		);
+	}
+}
+
+export async function mergeTracksByIsrc({
+	dryRun = true,
+	reportPath = getReportPath(),
+}: MergeTracksByIsrcOptions = {}) {
+	const startedAt = Date.now();
+	const report = new MigrationReport(reportPath);
+	await report.init(dryRun);
+	console.log(
+		`Step 1: running in ${dryRun ? "dry-run" : "apply"} mode${
+			dryRun ? " (pass --apply or DRY_RUN=false to write changes)" : ""
+		}`,
+	);
+	console.log(`Writing merge report to ${reportPath}`);
+	await report.write(
+		`Step 1: running in ${dryRun ? "dry-run" : "apply"} mode`,
+	);
+
+	console.log("Step 2: loading tracks with ISRCs");
+	const backfill = await backfillMissingIsrcs();
+	const tracksWithStoredIsrc = await TrackModel.find({
+		isrc: { $exists: true, $ne: null },
+		mergedInto: { $exists: false },
+	});
+	const tracks =
+		backfill.tracks.length > 0
+			? [
+					...tracksWithStoredIsrc,
+					...backfill.tracks.filter((track) => Boolean(track.isrc)),
+				]
+			: tracksWithStoredIsrc;
+
+	console.log("Step 3: grouping tracks by ISRC");
+	const tracksByIsrc = new Map<string, TrackDocument[]>();
+	for (const track of tracks) {
+		if (!track.isrc) {
+			continue;
+		}
+		const group = tracksByIsrc.get(track.isrc) ?? [];
+		group.push(track);
+		tracksByIsrc.set(track.isrc, group);
+	}
+	const duplicateGroups = [...tracksByIsrc.entries()].filter(
+		([, group]) => group.length > 1,
+	);
+	const redundantTracks = duplicateGroups.reduce(
+		(total, [, group]) => total + group.length - 1,
+		0,
+	);
+	console.log(
+		`Found ${duplicateGroups.length} unique ISRCs with duplicates, ${redundantTracks} total redundant track documents`,
+	);
+	await report.write(`Total ISRCs backfilled: ${backfill.backfilledCount}`);
+	await report.write(
+		`Found ${duplicateGroups.length} unique ISRCs with duplicates, ${redundantTracks} total redundant track documents`,
+	);
+	await report.section("Duplicate Groups");
+
+	const duplicateTrackIds = new Set(
+		duplicateGroups.flatMap(([, group]) => group.map((track) => track.id)),
+	);
+	const uniqueBackfilledTracks = backfill.tracks.filter(
+		(track) => track.isrc && !duplicateTrackIds.has(track.id),
+	);
+	if (!dryRun && uniqueBackfilledTracks.length > 0) {
+		await TrackModel.bulkWrite(
+			uniqueBackfilledTracks.map((track) => ({
+				updateOne: {
+					filter: { id: track.id, mergedInto: { $exists: false } },
+					update: { $set: { isrc: track.isrc } },
+				},
+			})),
+			{ ordered: false },
+		);
+		console.log(
+			`Stored ISRCs on ${uniqueBackfilledTracks.length} non-duplicate tracks`,
+		);
+	}
+
+	let infosUpdated = 0;
+	let tracksMarkedMerged = 0;
+
+	for (const [isrc, group] of duplicateGroups) {
+		const trackIds = group.map((track) => track.id);
+		const playCountsByTrackId = await getPlayCounts(trackIds);
+		const primary = electPrimary(group, playCountsByTrackId);
+		if (!primary) {
+			continue;
+		}
+		const secondaries = group.filter((track) => track.id !== primary.id);
+		const secondarySummary = secondaries
+			.map(
+				(track) =>
+					`${track.id} (${playCountsByTrackId.get(track.id) ?? 0} plays)`,
+			)
+			.join(", ");
+
+		console.log(
+			`ISRC ${isrc}: primary=${primary.id} (${primary.name}, ${
+				playCountsByTrackId.get(primary.id) ?? 0
+			} plays), merging ${secondarySummary}`,
+		);
+		await writeMergeReportGroup(
+			report,
+			isrc,
+			primary,
+			secondaries,
+			playCountsByTrackId,
+		);
+
+		if (dryRun) {
+			await report.write("Action: dry-run only, no database writes");
+			await report.write("");
+			continue;
+		}
+
+		let groupInfosUpdated = 0;
+		let groupTracksMarkedMerged = 0;
+		for (const secondaryIdBatch of chunk(
+			secondaries.map((track) => track.id),
+			UPDATE_BATCH_SIZE,
+		)) {
+			const infoUpdate = await InfosModel.updateMany(
+				{ id: { $in: secondaryIdBatch } },
+				{ $set: { id: primary.id } },
+			);
+			groupInfosUpdated += infoUpdate.modifiedCount;
+
+			const trackUpdate = await TrackModel.updateMany(
+				{
+					id: { $in: secondaryIdBatch },
+					mergedInto: { $exists: false },
+				},
+				{
+					$set: { mergedInto: primary.id },
+					$unset: { isrc: "" },
+				},
+			);
+			groupTracksMarkedMerged += trackUpdate.modifiedCount;
+		}
+		await TrackModel.updateOne(
+			{ id: primary.id, mergedInto: { $exists: false } },
+			{ $set: { isrc } },
+		);
+		infosUpdated += groupInfosUpdated;
+		tracksMarkedMerged += groupTracksMarkedMerged;
+		console.log(
+			`Updated ${groupInfosUpdated} listen records; marked ${groupTracksMarkedMerged} secondary tracks as merged`,
+		);
+		await report.write(`Listen records re-pointed: ${groupInfosUpdated}`);
+		await report.write(
+			`Secondary tracks marked as merged: ${groupTracksMarkedMerged}`,
+		);
+		await report.write("");
+	}
+
+	const mergedAuditCount = await writeExistingMergeAudit(report);
+	const elapsedMs = Date.now() - startedAt;
+	const summary: MergeTracksByIsrcSummary = {
+		dryRun,
+		duplicateIsrcs: duplicateGroups.length,
+		redundantTracks,
+		infosUpdated,
+		tracksMarkedMerged,
+		elapsedMs,
+		reportPath,
+	};
+
+	await report.section("Final Summary");
+	await report.write(`Total ISRCs backfilled: ${backfill.backfilledCount}`);
+	await report.write(`Total ISRCs processed: ${summary.duplicateIsrcs}`);
+	await report.write(`Total listen records re-pointed: ${summary.infosUpdated}`);
+	await report.write(
+		`Total secondary tracks marked as merged: ${summary.tracksMarkedMerged}`,
+	);
+	await report.write(`Total currently merged secondary tracks: ${mergedAuditCount}`);
+	await report.write(`Elapsed time: ${summary.elapsedMs}ms`);
+	await report.write(`Finished: ${new Date().toISOString()}`);
+
+	console.log("Step 7: final summary");
+	console.log(`Total ISRCs backfilled: ${backfill.backfilledCount}`);
+	console.log(`Total ISRCs processed: ${summary.duplicateIsrcs}`);
+	console.log(`Total listen records re-pointed: ${summary.infosUpdated}`);
+	console.log(
+		`Total secondary tracks marked as merged: ${summary.tracksMarkedMerged}`,
+	);
+	console.log(`Total currently merged secondary tracks: ${mergedAuditCount}`);
+	console.log(`Elapsed time: ${summary.elapsedMs}ms`);
+	console.log(`Report written to: ${summary.reportPath}`);
+
+	return summary;
+}
+
+export async function runMergeTracksByIsrcCli(args = process.argv.slice(2)) {
+	const dryRun = getDryRunMode(args);
+	const reportPath = getReportPath(args);
+	const endpoint = process.env.MONGO_ENDPOINT ?? DEFAULT_MONGO_ENDPOINT;
+
+	try {
+		console.log(`Connecting to MongoDB at ${endpoint}`);
+		await mongoose.connect(endpoint);
+		await mergeTracksByIsrc({ dryRun, reportPath });
+	} catch (error) {
+		console.error("Failed to merge tracks by ISRC", error);
+		process.exitCode = 1;
+	} finally {
+		await mongoose.disconnect();
+		console.log("Disconnected from MongoDB");
+	}
+}

--- a/apps/server/src/migrations/run.ts
+++ b/apps/server/src/migrations/run.ts
@@ -1,0 +1,3 @@
+import { runMergeTracksByIsrcCli } from "./mergeTracksByIsrc";
+
+void runMergeTracksByIsrcCli();

--- a/apps/server/src/routes/track.ts
+++ b/apps/server/src/routes/track.ts
@@ -12,6 +12,7 @@ import {
   ItemType,
 } from "../database";
 import { getAlbums } from "../database/queries/album";
+import { Artist } from "../database/schemas/artist";
 import { isLoggedOrGuest, validate } from "../tools/middleware";
 import { LoggedRequest } from "../tools/types";
 
@@ -39,15 +40,14 @@ router.get("/:id/stats", isLoggedOrGuest, async (req, res) => {
   const { user } = req as LoggedRequest;
   const { id } = validate(req.params, getTrackStats);
   const [track] = await getTracks([id]);
-  const [trackArtist] = track?.artists ?? [];
-  if (!track || !trackArtist) {
+  if (!track) {
     res.status(404).end();
     return;
   }
   const promises = [
     getAlbums([track.album]),
     getTrackListenedCount(user, id),
-    getArtists([trackArtist]),
+    getArtists(track.artists),
     getTrackFirstAndLastListened(user, track.id),
     getTrackListenedAlbums(user, track.id),
     bestPeriodOfTrack(user, track.id),
@@ -56,20 +56,23 @@ router.get("/:id/stats", isLoggedOrGuest, async (req, res) => {
   const [
     [album],
     count,
-    [artist],
+    artists,
     firstLast,
     listenedOn,
     bestPeriod,
     recentHistory,
   ] =
     await Promise.all(promises);
+  const orderedArtists = track.artists
+    .map(artistId => artists.find((artist: Artist) => artist.id === artistId))
+    .filter((artist): artist is Artist => Boolean(artist));
   if (!count) {
     res.status(200).send({ code: "NEVER_LISTENED" });
     return;
   }
   res.status(200).send({
     track,
-    artist,
+    artists: orderedArtists,
     album,
     listenedOn,
     bestPeriod,

--- a/apps/server/src/routes/track.ts
+++ b/apps/server/src/routes/track.ts
@@ -5,6 +5,7 @@ import {
   getTracks,
   getTrackListenedCount,
   getTrackFirstAndLastListened,
+  getTrackListenedAlbums,
   bestPeriodOfTrack,
   getTrackRecentHistory,
   getRankOf,
@@ -48,10 +49,19 @@ router.get("/:id/stats", isLoggedOrGuest, async (req, res) => {
     getTrackListenedCount(user, id),
     getArtists([trackArtist]),
     getTrackFirstAndLastListened(user, track.id),
+    getTrackListenedAlbums(user, track.id),
     bestPeriodOfTrack(user, track.id),
     getTrackRecentHistory(user, track.id),
   ];
-  const [[album], count, [artist], firstLast, bestPeriod, recentHistory] =
+  const [
+    [album],
+    count,
+    [artist],
+    firstLast,
+    listenedOn,
+    bestPeriod,
+    recentHistory,
+  ] =
     await Promise.all(promises);
   if (!count) {
     res.status(200).send({ code: "NEVER_LISTENED" });
@@ -61,6 +71,7 @@ router.get("/:id/stats", isLoggedOrGuest, async (req, res) => {
     track,
     artist,
     album,
+    listenedOn,
     bestPeriod,
     firstLast,
     recentHistory,

--- a/apps/server/src/spotify/dbTools.ts
+++ b/apps/server/src/spotify/dbTools.ts
@@ -16,6 +16,161 @@ import { longWriteDbLock } from "../tools/lock";
 import { Metrics } from "../tools/metrics";
 import { compact } from "../tools/utils";
 
+interface TracksAlbumsArtistsResult {
+	tracks: Track[];
+	albums: Album[];
+	artists: Artist[];
+	tracksBySpotifyId: Map<string, Track>;
+}
+
+interface TrackCanonicalizationResult {
+	canonicalIdBySpotifyId: Map<string, string>;
+	missingTrackIds: string[];
+}
+
+const spotifyTrackToStoredTrack = (track: SpotifyTrack): Track => ({
+	...track,
+	album: track.album.id,
+	artists: track.artists.map((e) => e.id),
+	isrc: track.external_ids?.isrc,
+});
+
+const getSpotifyTrackIsrcs = (spotifyTracks: SpotifyTrack[]) => [
+	...new Set(
+		spotifyTracks
+			.map((track) => track.external_ids?.isrc)
+			.filter((isrc): isrc is string => Boolean(isrc)),
+	),
+];
+
+const getStoredTracksByIdOrIsrc = (ids: string[], isrcs: string[]) =>
+	TrackModel.find({
+		$or: [
+			{ id: { $in: ids } },
+			...(isrcs.length > 0
+				? [{ isrc: { $in: isrcs }, mergedInto: { $exists: false } }]
+				: []),
+		],
+	});
+
+function canonicalizeSpotifyTracks(
+	spotifyTracks: SpotifyTrack[],
+	storedTracks: Track[],
+): TrackCanonicalizationResult {
+	const storedById = new Map(storedTracks.map((track) => [track.id, track]));
+	const storedByIsrc = new Map(
+		storedTracks
+			.filter((track) => track.isrc && !track.mergedInto)
+			.map((track) => [track.isrc!, track]),
+	);
+	const canonicalIdBySpotifyId = new Map<string, string>();
+	const pendingCanonicalIdByIsrc = new Map<string, string>();
+	const missingTrackIds: string[] = [];
+
+	for (const spotifyTrack of spotifyTracks) {
+		const isrc = spotifyTrack.external_ids?.isrc;
+		const storedByMatchingIsrc = isrc ? storedByIsrc.get(isrc) : undefined;
+		if (storedByMatchingIsrc) {
+			canonicalIdBySpotifyId.set(spotifyTrack.id, storedByMatchingIsrc.id);
+			continue;
+		}
+
+		const storedByMatchingId = storedById.get(spotifyTrack.id);
+		if (storedByMatchingId) {
+			const canonicalId = storedByMatchingId.mergedInto ?? storedByMatchingId.id;
+			canonicalIdBySpotifyId.set(spotifyTrack.id, canonicalId);
+			if (isrc && !pendingCanonicalIdByIsrc.has(isrc)) {
+				pendingCanonicalIdByIsrc.set(isrc, canonicalId);
+			}
+			continue;
+		}
+
+		const pendingCanonicalId = isrc
+			? pendingCanonicalIdByIsrc.get(isrc)
+			: undefined;
+		if (pendingCanonicalId) {
+			canonicalIdBySpotifyId.set(spotifyTrack.id, pendingCanonicalId);
+			continue;
+		}
+
+		canonicalIdBySpotifyId.set(spotifyTrack.id, spotifyTrack.id);
+		missingTrackIds.push(spotifyTrack.id);
+		if (isrc) {
+			pendingCanonicalIdByIsrc.set(isrc, spotifyTrack.id);
+		}
+	}
+
+	return { canonicalIdBySpotifyId, missingTrackIds };
+}
+
+const findMergedIntoTracks = async (storedTracks: Track[]) => {
+	const mergedIntoIds = [
+		...new Set(
+			storedTracks
+				.map((track) => track.mergedInto)
+				.filter((id): id is string => Boolean(id)),
+		),
+	];
+	return mergedIntoIds.length > 0
+		? TrackModel.find({ id: { $in: mergedIntoIds } })
+		: [];
+};
+
+async function updateExistingTrackIsrcs(
+	spotifyTracks: SpotifyTrack[],
+	storedTracks: Track[],
+	canonicalIdBySpotifyId: Map<string, string>,
+) {
+	const storedById = new Map(storedTracks.map((track) => [track.id, track]));
+	const updates = spotifyTracks.flatMap((track) => {
+		const isrc = track.external_ids?.isrc;
+		const storedTrack = storedById.get(track.id);
+		if (
+			!isrc ||
+			!storedTrack ||
+			storedTrack.mergedInto ||
+			storedTrack.isrc === isrc ||
+			canonicalIdBySpotifyId.get(track.id) !== track.id
+		) {
+			return [];
+		}
+		return [
+			{
+				updateOne: {
+					filter: { id: track.id },
+					update: { $set: { isrc } },
+				},
+			},
+		];
+	});
+
+	if (updates.length === 0) {
+		return;
+	}
+
+	try {
+		await TrackModel.bulkWrite(updates, { ordered: false });
+	} catch (error) {
+		logger.warn("Could not update ISRCs on existing tracks", error);
+	}
+}
+
+function mapSpotifyIdsToCanonicalTracks(
+	spotifyTracks: SpotifyTrack[],
+	canonicalIdBySpotifyId: Map<string, string>,
+	tracks: Track[],
+) {
+	const tracksById = new Map(tracks.map((track) => [track.id, track]));
+
+	return new Map(
+		spotifyTracks.flatMap((track) => {
+			const canonicalId = canonicalIdBySpotifyId.get(track.id);
+			const storedTrack = canonicalId ? tracksById.get(canonicalId) : null;
+			return storedTrack ? [[track.id, storedTrack] as const] : [];
+		}),
+	);
+}
+
 export const getTracks = async (userId: string, ids: string[]) => {
 	const client = new SpotifyAPI(userId);
 	const spotifyTracks = compact(await client.getTracks(ids));
@@ -24,11 +179,7 @@ export const getTracks = async (userId: string, ids: string[]) => {
 		logger.info(
 			`Storing non existing track ${track.name} by ${track.artists[0]?.name}`,
 		);
-		return {
-			...track,
-			album: track.album.id,
-			artists: track.artists.map((e) => e.id),
-		};
+		return spotifyTrackToStoredTrack(track);
 	});
 	Metrics.ingestedTracksTotal.inc({ user: userId }, tracks.length);
 
@@ -80,44 +231,76 @@ const getTracksAndRelatedAlbumArtists = async (
 	};
 };
 
+const getSourceAlbumArtistIds = (spotifyTracks: SpotifyTrack[]) => ({
+	artists: [
+		...new Set(
+			spotifyTracks
+				.flatMap((track) => track.artists.map((artist) => artist.id))
+				.filter(Boolean),
+		),
+	],
+	albums: [
+		...new Set(spotifyTracks.map((track) => track.album.id).filter(Boolean)),
+	],
+});
+
 export const getTracksAlbumsArtists = async (
 	userId: string,
 	spotifyTracks: SpotifyTrack[],
-) => {
-	const ids = spotifyTracks.map((track) => track.id);
-	const storedTracks: Track[] = await TrackModel.find({ id: { $in: ids } });
-	const missingTrackIds = ids.filter(
-		(id) =>
-			!storedTracks.find((stored) => stored.id.toString() === id.toString()),
-	);
-
-	if (missingTrackIds.length === 0) {
-		logger.info("No missing tracks, passing...");
+): Promise<TracksAlbumsArtistsResult> => {
+	if (spotifyTracks.length === 0) {
 		return {
 			tracks: [],
 			albums: [],
 			artists: [],
+			tracksBySpotifyId: new Map<string, Track>(),
 		};
 	}
+
+	const ids = spotifyTracks.map((track) => track.id);
+	const isrcs = getSpotifyTrackIsrcs(spotifyTracks);
+	const storedTracks: Track[] = await getStoredTracksByIdOrIsrc(ids, isrcs);
+	const { canonicalIdBySpotifyId, missingTrackIds } =
+		canonicalizeSpotifyTracks(spotifyTracks, storedTracks);
+	const mergedIntoTracks: Track[] = await findMergedIntoTracks(storedTracks);
+
+	await updateExistingTrackIsrcs(
+		spotifyTracks,
+		storedTracks,
+		canonicalIdBySpotifyId,
+	);
 
 	const {
 		tracks,
 		artists: relatedArtists,
 		albums: relatedAlbums,
-	} = await getTracksAndRelatedAlbumArtists(userId, missingTrackIds);
+	} =
+		missingTrackIds.length > 0
+			? await getTracksAndRelatedAlbumArtists(userId, missingTrackIds)
+			: { tracks: [], artists: [], albums: [] };
+	if (missingTrackIds.length === 0) {
+		logger.info("No missing tracks, passing...");
+	}
+	const sourceRelated = getSourceAlbumArtistIds(spotifyTracks);
+	const allRelatedAlbums = [
+		...new Set([...relatedAlbums, ...sourceRelated.albums]),
+	];
+	const allRelatedArtists = [
+		...new Set([...relatedArtists, ...sourceRelated.artists]),
+	];
 
 	const storedAlbums: Album[] = await AlbumModel.find({
-		id: { $in: relatedAlbums },
+		id: { $in: allRelatedAlbums },
 	});
-	const missingAlbumIds = relatedAlbums.filter(
+	const missingAlbumIds = allRelatedAlbums.filter(
 		(alb) =>
 			!storedAlbums.find((salb) => salb.id.toString() === alb.toString()),
 	);
 
 	const storedArtists: Artist[] = await ArtistModel.find({
-		id: { $in: relatedArtists },
+		id: { $in: allRelatedArtists },
 	});
-	const missingArtistIds = relatedArtists.filter(
+	const missingArtistIds = allRelatedArtists.filter(
 		(alb) =>
 			!storedArtists.find((salb) => salb.id.toString() === alb.toString()),
 	);
@@ -133,6 +316,11 @@ export const getTracksAlbumsArtists = async (
 		tracks,
 		albums,
 		artists,
+		tracksBySpotifyId: mapSpotifyIdsToCanonicalTracks(
+			spotifyTracks,
+			canonicalIdBySpotifyId,
+			[...storedTracks, ...mergedIntoTracks, ...tracks],
+		),
 	};
 };
 
@@ -146,7 +334,18 @@ export async function storeTrackAlbumArtist({
 	artists?: Artist[];
 }) {
 	if (tracks) {
-		await TrackModel.create(uniqBy(tracks, (item) => item.id));
+		const uniqueTracks = uniqBy(tracks, (item) => item.id);
+		if (uniqueTracks.length > 0) {
+			await TrackModel.bulkWrite(
+				uniqueTracks.map((track) => ({
+					updateOne: {
+						filter: { id: track.id },
+						update: { $set: track },
+						upsert: true,
+					},
+				})),
+			);
+		}
 	}
 	if (albums) {
 		await AlbumModel.create(uniqBy(albums, (item) => item.id));
@@ -166,26 +365,28 @@ export async function storeIterationOfLoop(
 ) {
 	await longWriteDbLock.lock();
 
-	await storeTrackAlbumArtist({
-		tracks,
-		albums,
-		artists,
-	});
+	try {
+		await storeTrackAlbumArtist({
+			tracks,
+			albums,
+			artists,
+		});
 
-	await addTrackIdsToUser(userId, infos);
+		await addTrackIdsToUser(userId, infos);
 
-	await storeInUser("_id", new mongoose.Types.ObjectId(userId), {
-		lastTimestamp: iterationTimestamp,
-	});
+		await storeInUser("_id", new mongoose.Types.ObjectId(userId), {
+			lastTimestamp: iterationTimestamp,
+		});
 
-	const min = minOfArray(infos, (item) => item.played_at.getTime());
+		const min = minOfArray(infos, (item) => item.played_at.getTime());
 
-	if (min) {
-		const minInfo = infos[min.minIndex]?.played_at;
-		if (minInfo) {
-			await storeFirstListenedAtIfLess(userId, minInfo);
+		if (min) {
+			const minInfo = infos[min.minIndex]?.played_at;
+			if (minInfo) {
+				await storeFirstListenedAtIfLess(userId, minInfo);
+			}
 		}
+	} finally {
+		longWriteDbLock.unlock();
 	}
-
-	longWriteDbLock.unlock();
 }

--- a/apps/server/src/spotify/looper.ts
+++ b/apps/server/src/spotify/looper.ts
@@ -49,17 +49,19 @@ const loop = async (user: User) => {
   }
 
   const spotifyTracks = items.map(e => e.track);
-  const { tracks, albums, artists } = await getTracksAlbumsArtists(
-    user._id.toString(),
-    spotifyTracks,
-  );
+  const { tracks, albums, artists, tracksBySpotifyId } =
+    await getTracksAlbumsArtists(user._id.toString(), spotifyTracks);
   const infos: Omit<Infos, "owner">[] = [];
   for (let i = 0; i < items.length; i += 1) {
     const item = items[i]!;
+    const track = tracksBySpotifyId.get(item.track.id);
+    if (!track) {
+      continue;
+    }
     const date = new Date(item.played_at);
     const duplicate = await getCloseTrackId(
       user._id.toString(),
-      item.track.id,
+      track.id,
       date,
       30,
     );
@@ -77,7 +79,7 @@ const loop = async (user: User) => {
         albumId: item.track.album.id,
         primaryArtistId: primaryArtist.id,
         artistIds: item.track.artists.map(e => e.id),
-        id: item.track.id,
+        id: track.id,
         ...(isBlacklisted ? { blacklistedBy: "artist" } : {}),
       });
     }

--- a/apps/server/src/tools/importers/full_privacy.ts
+++ b/apps/server/src/tools/importers/full_privacy.ts
@@ -72,10 +72,11 @@ export class FullPrivacyImporter
 	};
 
 	storeItems = async (userId: string, items: RecentlyPlayedTrack[]) => {
-		const { tracks, albums, artists } = await getTracksAlbumsArtists(
-			userId,
-			items.map((it) => it.track),
-		);
+		const { tracks, albums, artists, tracksBySpotifyId } =
+			await getTracksAlbumsArtists(
+				userId,
+				items.map((it) => it.track),
+			);
 		await storeTrackAlbumArtist({
 			tracks,
 			albums,
@@ -84,10 +85,14 @@ export class FullPrivacyImporter
 		const finalInfos: Omit<Infos, "owner">[] = [];
 		for (let i = 0; i < items.length; i += 1) {
 			const item = items[i]!;
+			const track = tracksBySpotifyId.get(item.track.id);
+			if (!track) {
+				continue;
+			}
 			const date = new Date(item.played_at);
 			const duplicate = await getCloseTrackId(
 				this.userId.toString(),
-				item.track.id,
+				track.id,
 				date,
 				60,
 			);
@@ -106,7 +111,7 @@ export class FullPrivacyImporter
 			}
 			finalInfos.push({
 				played_at: date,
-				id: item.track.id,
+				id: track.id,
 				primaryArtistId: primaryArtist.id,
 				albumId: item.track.album.id,
 				artistIds: item.track.artists.map((e) => e.id),

--- a/apps/server/src/tools/importers/privacy.ts
+++ b/apps/server/src/tools/importers/privacy.ts
@@ -72,18 +72,20 @@ export class PrivacyImporter
   };
 
   storeItems = async (userId: string, items: RecentlyPlayedTrack[]) => {
-    const { tracks, albums, artists } = await getTracksAlbumsArtists(
-      userId,
-      items.map(it => it.track),
-    );
+    const { tracks, albums, artists, tracksBySpotifyId } =
+      await getTracksAlbumsArtists(userId, items.map(it => it.track));
     await storeTrackAlbumArtist({ tracks, albums, artists });
     const finalInfos: Omit<Infos, "owner">[] = [];
     for (let i = 0; i < items.length; i += 1) {
       const item = items[i]!;
+      const track = tracksBySpotifyId.get(item.track.id);
+      if (!track) {
+        continue;
+      }
       const date = new Date(`${item.played_at}Z`);
       const duplicate = await getCloseTrackId(
         this.userId.toString(),
-        item.track.id,
+        track.id,
         date,
         60,
       );
@@ -102,7 +104,7 @@ export class PrivacyImporter
       }
       finalInfos.push({
         played_at: date,
-        id: item.track.id,
+        id: track.id,
         primaryArtistId: primaryArtist.id,
         albumId: item.track.album.id,
         artistIds: item.track.artists.map(e => e.id),


### PR DESCRIPTION
## Summary

This PR adds ISRC-based track deduplication so the same recording is counted as one track even when Spotify exposes it through multiple track IDs, such as on singles, EPs, albums, deluxe editions, or regional releases.

Previously each Spotify track ID was treated as a separate song. This could split listening stats for the same recording across multiple track entries.

This fixes #465 and #469.

## What Changed

Track documents can now store Spotify ISRC metadata. When new Spotify tracks are processed, the server uses the ISRC to resolve them to an existing canonical track where possible instead of creating duplicate track records.

Listening history now keeps track identity and release context separate:

- `Infos.id` points to the canonical track/recording.
- `Infos.albumId` keeps the album or release that was actually listened to.

This means track stats can count the same recording together, while album stats still count toward the release the user actually played.

For example, if the same song appears on both an EP and an album:

- the song’s track count is shared,
- an EP listen still counts toward the EP,
- an album listen still counts toward the album.

The normal Spotify sync flow and both Spotify privacy importers were updated to use this same behavior.

## Existing Data Migration

A manual migration script was added for users who want to deduplicate their existing listening history.

The migration is dry-run by default and can generate a report of the planned or applied merges. Full usage instructions are documented in:

```bash
apps/server/ISRC_DEDUPLICATION.md
```

If users do not run the migration, the application continues to work, but existing duplicate tracks remain split until migrated.

## Additional Fixes

Album and artist album statistics were adjusted to use the listened release from the history entry instead of the canonical track’s album. This avoids empty or incomplete album pages after deduplication and keeps album rankings accurate.

## Testing

No testing of the privacy or full privacy import was done.
Manually tested with duplicate Spotify tracks sharing the same ISRC, including recordings that appear on multiple releases. I  have been running this version along side my old instance and so far no problems or inconsistencies occurred.

### Before 
Same track listens from different albums are counted separate.

<img width="1672" height="45" alt="2026-04-17_21-15" src="https://github.com/user-attachments/assets/82678129-e1d3-4b5b-9390-cd92279635b7" />
<img width="1681" height="46" alt="2026-04-17_21-15_1" src="https://github.com/user-attachments/assets/a668e0dd-d80a-43d6-8947-b8d629c20d4c" />
<img width="826" height="535" alt="2026-04-17_21-19" src="https://github.com/user-attachments/assets/9992a1b3-afdb-4fbf-8d08-0f1f10901748" />

### After 
Entries have been merged but album listens stay the same.

<img width="1691" height="48" alt="2026-04-17_21-15_2" src="https://github.com/user-attachments/assets/f8ac9a64-86fc-416a-b4f0-416e0096df00" />
<img width="833" height="489" alt="2026-04-17_21-19_1" src="https://github.com/user-attachments/assets/e1d6d86a-6198-461f-a991-ed12a279f8c0" />

## Note
I don't know if this ever gets merged, but I will continue using both versions in parallel and compare both at the end of the year. I am open for suggestions: maybe something like a toggle switch in the settings could be implemented, etc.