### PR TITLE
Fix : getAlbumsWithoutArtist() returning no results

### DIFF
--- a/apps/server/src/database/queries/tools.ts
+++ b/apps/server/src/database/queries/tools.ts
@@ -43,6 +43,6 @@ export const getAlbumsWithoutArtist = () =>
         foreignField: "id",
       },
     },
-    { $unwind: "$full_artists" },
+    { $unwind: { path: "$full_artists", preserveNullAndEmptyArrays: true } },
     { $match: { full_artists: null } },
   ]);

--- a/apps/server/src/database/queries/tools.ts
+++ b/apps/server/src/database/queries/tools.ts
@@ -39,7 +39,7 @@ export const getAlbumsWithoutArtist = () =>
       $lookup: {
         from: "artists",
         as: "full_artists",
-        localField: "album",
+        localField: "artists",
         foreignField: "id",
       },
     },


### PR DESCRIPTION
Fixed #605 by making a small change in the getAlbumsWithoutArtist() to prevent not returning albums without an artist in the database (Inspired by the 2 other functions getTracksWithoutAlbum() and getInfoswithoutTrack())
See the test in #605 