### PR TITLE
fix: correct import warning copy

### DIFF
--- a/apps/client/src/scenes/Settings/Importer/FullPrivacy/FullPrivacy.tsx
+++ b/apps/client/src/scenes/Settings/Importer/FullPrivacy/FullPrivacy.tsx
@@ -67,7 +67,7 @@ export default function FullPrivacy() {
         ))}
       {wrongFiles && (
         <Text className={s.alert} size='normal'>
-          Some file do not being with <code>Streaming_History_Audio</code>,
+          Some files do not begin with <code>Streaming_History_Audio</code>,
           import might not work
         </Text>
       )}

--- a/apps/client/src/scenes/Settings/Importer/Privacy/Privacy.tsx
+++ b/apps/client/src/scenes/Settings/Importer/Privacy/Privacy.tsx
@@ -63,7 +63,7 @@ export default function Privacy() {
         ))}
       {wrongFiles && (
         <Text className={s.alert} size='normal'>
-          Some file do not being with <code>StreamingHistory</code>, import
+          Some files do not begin with <code>StreamingHistory</code>, import
           might not work
         </Text>
       )}


### PR DESCRIPTION
Fixes Yooooomi/your_spotify#621.

## Summary
- Correct the full privacy import warning from `Some file do not being` to `Some files do not begin`.
- Apply the same grammar fix to the regular privacy import warning for consistency.

## Testing
- `git diff --check`
- `rg -n 'Some file do not being|Some files do not begin|Streaming_History_Audio|StreamingHistory' apps/client/src/scenes/Settings/Importer`