### PR TITLE
Handle spotify refresh token expiration

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -24,6 +24,7 @@ import Affinity from "./scenes/Collaborative/Affinity";
 import { useTheme } from "./services/theme";
 import { selectDarkMode } from "./services/redux/modules/user/selector";
 import PlaylistDialog from "./components/PlaylistDialog";
+import SpotifyAuthRefreshDialog from "./components/SpotifyAuthRefreshDialog";
 import TrackStats from "./scenes/TrackStats";
 import LongestSessions from "./scenes/LongestSessions";
 import AlbumStats from "./scenes/AlbumStats";
@@ -56,6 +57,7 @@ function App() {
             <Wrapper />
             <Message />
             <PlaylistDialog />
+            <SpotifyAuthRefreshDialog />
             <Layout>
               <Routes>
                 <Route

--- a/apps/client/src/components/SpotifyAuthRefreshDialog/SpotifyAuthRefreshDialog.tsx
+++ b/apps/client/src/components/SpotifyAuthRefreshDialog/SpotifyAuthRefreshDialog.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { Button } from "@mui/material";
+import { useSelector } from "react-redux";
+import Dialog from "../Dialog";
+import SimpleDialogContent from "../SimpleDialogContent";
+import {
+  selectIsPublic,
+  selectUser,
+} from "../../services/redux/modules/user/selector";
+import { getSpotifyLogUrl } from "../../services/tools";
+
+// Spotify expires refresh tokens six months after the user authorized the
+// app. Proposing a re-log after one month keeps the authorization fresh as
+// long as the user opens the dashboard at least once every five months.
+const PROPOSE_REFRESH_AFTER_DAYS = 30;
+const DISMISSED_KEY = "spotify-auth-refresh-dismissed";
+
+export default function SpotifyAuthRefreshDialog() {
+  const user = useSelector(selectUser);
+  const isPublic = useSelector(selectIsPublic);
+  const [dismissed, setDismissed] = useState(
+    () => sessionStorage.getItem(DISMISSED_KEY) === "true",
+  );
+
+  if (!user || user.isGuest || isPublic || dismissed) {
+    return null;
+  }
+
+  const authAgeDays = user.spotifyAuthDate
+    ? Math.floor(
+        (Date.now() - new Date(user.spotifyAuthDate).getTime()) /
+          (1000 * 60 * 60 * 24),
+      )
+    : undefined;
+  if (authAgeDays !== undefined && authAgeDays < PROPOSE_REFRESH_AFTER_DAYS) {
+    return null;
+  }
+
+  const dismiss = () => {
+    sessionStorage.setItem(DISMISSED_KEY, "true");
+    setDismissed(true);
+  };
+
+  return (
+    <Dialog
+      open
+      maxWidth="sm"
+      title="Refresh your Spotify authorization"
+      onClose={dismiss}>
+      <SimpleDialogContent
+        message={`${
+          authAgeDays === undefined
+            ? "You authorized Spotify on this account at an unknown date."
+            : `You authorized Spotify ${authAgeDays} days ago.`
+        } Spotify expires authorizations six months after sign-in, which would interrupt the tracking of your listening history. Refreshing it now only takes a second and does not require approving the app again.`}
+        actions={
+          <>
+            <Button onClick={dismiss}>Remind me later</Button>
+            <Button variant="contained" href={getSpotifyLogUrl()}>
+              Refresh authorization
+            </Button>
+          </>
+        }
+      />
+    </Dialog>
+  );
+}

--- a/apps/client/src/components/SpotifyAuthRefreshDialog/SpotifyAuthRefreshDialog.tsx
+++ b/apps/client/src/components/SpotifyAuthRefreshDialog/SpotifyAuthRefreshDialog.tsx
@@ -26,13 +26,21 @@ export default function SpotifyAuthRefreshDialog() {
     return null;
   }
 
+  // The server discards the tokens and sets this flag when Spotify rejects
+  // a refresh, no matter how recent the authorization is.
+  const tokenDiscarded = Boolean(user.spotifyReauthRequired);
+
   const authAgeDays = user.spotifyAuthDate
     ? Math.floor(
         (Date.now() - new Date(user.spotifyAuthDate).getTime()) /
           (1000 * 60 * 60 * 24),
       )
     : undefined;
-  if (authAgeDays !== undefined && authAgeDays < PROPOSE_REFRESH_AFTER_DAYS) {
+  if (
+    !tokenDiscarded &&
+    authAgeDays !== undefined &&
+    authAgeDays < PROPOSE_REFRESH_AFTER_DAYS
+  ) {
     return null;
   }
 
@@ -48,11 +56,15 @@ export default function SpotifyAuthRefreshDialog() {
       title="Refresh your Spotify authorization"
       onClose={dismiss}>
       <SimpleDialogContent
-        message={`${
-          authAgeDays === undefined
-            ? "You authorized Spotify on this account at an unknown date."
-            : `You authorized Spotify ${authAgeDays} days ago.`
-        } Spotify expires authorizations six months after sign-in, which would interrupt the tracking of your listening history. Refreshing it now only takes a second and does not require approving the app again.`}
+        message={
+          tokenDiscarded
+            ? "Your Spotify authorization has expired or was revoked, and the tracking of your listening history has stopped. Refresh it to resume tracking."
+            : `${
+                authAgeDays === undefined
+                  ? "You authorized Spotify on this account at an unknown date."
+                  : `You authorized Spotify ${authAgeDays} days ago.`
+              } Spotify expires authorizations six months after sign-in, which would interrupt the tracking of your listening history. Refreshing it now only takes a second and does not require approving the app again.`
+        }
         actions={
           <>
             <Button onClick={dismiss}>Remind me later</Button>

--- a/apps/client/src/components/SpotifyAuthRefreshDialog/SpotifyAuthRefreshDialog.tsx
+++ b/apps/client/src/components/SpotifyAuthRefreshDialog/SpotifyAuthRefreshDialog.tsx
@@ -1,17 +1,17 @@
-import { useState } from "react";
 import { Button } from "@mui/material";
+import { useState } from "react";
 import { useSelector } from "react-redux";
-import Dialog from "../Dialog";
-import SimpleDialogContent from "../SimpleDialogContent";
+
 import {
   selectIsPublic,
   selectUser,
 } from "../../services/redux/modules/user/selector";
 import { getSpotifyLogUrl } from "../../services/tools";
+import Dialog from "../Dialog";
+import SimpleDialogContent from "../SimpleDialogContent";
 
-// Spotify expires refresh tokens six months after the user authorized the
-// app. Proposing a re-log after one month keeps the authorization fresh as
-// long as the user opens the dashboard at least once every five months.
+// Spotify expires authorizations after six months, so prompting at one month
+// leaves five months of margin for the user to open the dashboard.
 const PROPOSE_REFRESH_AFTER_DAYS = 30;
 const DISMISSED_KEY = "spotify-auth-refresh-dismissed";
 
@@ -26,10 +26,12 @@ export default function SpotifyAuthRefreshDialog() {
     return null;
   }
 
-  // The server discards the tokens and sets this flag when Spotify rejects
-  // a refresh, no matter how recent the authorization is.
+  // Set by the server when Spotify rejected a refresh and the tokens were
+  // discarded.
   const tokenDiscarded = Boolean(user.spotifyReauthRequired);
 
+  // Accounts that authorized before this field existed have no date, they only
+  // get prompted once their tokens are actually discarded.
   const authAgeDays = user.spotifyAuthDate
     ? Math.floor(
         (Date.now() - new Date(user.spotifyAuthDate).getTime()) /
@@ -38,8 +40,7 @@ export default function SpotifyAuthRefreshDialog() {
     : undefined;
   if (
     !tokenDiscarded &&
-    authAgeDays !== undefined &&
-    authAgeDays < PROPOSE_REFRESH_AFTER_DAYS
+    (authAgeDays === undefined || authAgeDays < PROPOSE_REFRESH_AFTER_DAYS)
   ) {
     return null;
   }
@@ -59,11 +60,7 @@ export default function SpotifyAuthRefreshDialog() {
         message={
           tokenDiscarded
             ? "Your Spotify authorization has expired or was revoked, and the tracking of your listening history has stopped. Refresh it to resume tracking."
-            : `${
-                authAgeDays === undefined
-                  ? "You authorized Spotify on this account at an unknown date."
-                  : `You authorized Spotify ${authAgeDays} days ago.`
-              } Spotify expires authorizations six months after sign-in, which would interrupt the tracking of your listening history. Refreshing it now only takes a second and does not require approving the app again.`
+            : `You authorized Spotify ${authAgeDays} days ago. Spotify expires authorizations six months after sign-in, which would interrupt the tracking of your listening history. Refreshing it now only takes a second.`
         }
         actions={
           <>

--- a/apps/client/src/components/SpotifyAuthRefreshDialog/index.ts
+++ b/apps/client/src/components/SpotifyAuthRefreshDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpotifyAuthRefreshDialog";

--- a/apps/client/src/services/redux/modules/user/types.ts
+++ b/apps/client/src/services/redux/modules/user/types.ts
@@ -9,6 +9,7 @@ export interface User {
   expiresIn: number;
   accessToken: string;
   refreshToken: string;
+  spotifyAuthDate?: string;
   lastTimestamp: number;
   tracks: string[];
   settings: {

--- a/apps/client/src/services/redux/modules/user/types.ts
+++ b/apps/client/src/services/redux/modules/user/types.ts
@@ -7,9 +7,12 @@ export interface User {
   _id: string;
   id: string;
   expiresIn: number;
-  accessToken: string;
-  refreshToken: string;
+  // accessToken and refreshToken are stripped by the server before being
+  // sent to the client
+  accessToken?: string | null;
+  refreshToken?: string | null;
   spotifyAuthDate?: string;
+  spotifyReauthRequired?: boolean;
   lastTimestamp: number;
   tracks: string[];
   settings: {

--- a/apps/client/src/services/redux/modules/user/types.ts
+++ b/apps/client/src/services/redux/modules/user/types.ts
@@ -7,8 +7,7 @@ export interface User {
   _id: string;
   id: string;
   expiresIn: number;
-  // accessToken and refreshToken are stripped by the server before being
-  // sent to the client
+  // Stripped by the server before being sent to the client
   accessToken?: string | null;
   refreshToken?: string | null;
   spotifyAuthDate?: string;

--- a/apps/server/src/database/schemas/user.ts
+++ b/apps/server/src/database/schemas/user.ts
@@ -11,6 +11,7 @@ export interface User {
   accessToken: string | null;
   refreshToken: string | null;
   spotifyAuthDate?: Date;
+  spotifyReauthRequired?: boolean;
   lastTimestamp: number;
   tracks: Schema.Types.ObjectId[];
   settings: {
@@ -37,6 +38,7 @@ export const UserSchema = new Schema<User>(
     accessToken: { type: String, default: null },
     refreshToken: { type: String, default: null },
     spotifyAuthDate: { type: Date },
+    spotifyReauthRequired: { type: Boolean },
     lastTimestamp: { type: Number, default: 0 },
     tracks: {
       type: [Schema.Types.ObjectId],

--- a/apps/server/src/database/schemas/user.ts
+++ b/apps/server/src/database/schemas/user.ts
@@ -10,6 +10,7 @@ export interface User {
   expiresIn: number;
   accessToken: string | null;
   refreshToken: string | null;
+  spotifyAuthDate?: Date;
   lastTimestamp: number;
   tracks: Schema.Types.ObjectId[];
   settings: {
@@ -35,6 +36,7 @@ export const UserSchema = new Schema<User>(
     expiresIn: { type: Number, default: 0 },
     accessToken: { type: String, default: null },
     refreshToken: { type: String, default: null },
+    spotifyAuthDate: { type: Date },
     lastTimestamp: { type: Number, default: 0 },
     tracks: {
       type: [Schema.Types.ObjectId],

--- a/apps/server/src/routes/oauth.ts
+++ b/apps/server/src/routes/oauth.ts
@@ -98,7 +98,10 @@ router.get("/spotify/callback", withGlobalPreferences, async (req, res) => {
         nbUsers === 0,
       );
     }
-    await storeInUser("_id", user._id, infos);
+    await storeInUser("_id", user._id, {
+      ...infos,
+      spotifyAuthDate: new Date(),
+    });
     const privateData = await getPrivateData();
     if (!privateData?.jwtPrivateKey) {
       throw new Error("No private data found, cannot sign JWT");

--- a/apps/server/src/routes/oauth.ts
+++ b/apps/server/src/routes/oauth.ts
@@ -101,6 +101,7 @@ router.get("/spotify/callback", withGlobalPreferences, async (req, res) => {
     await storeInUser("_id", user._id, {
       ...infos,
       spotifyAuthDate: new Date(),
+      spotifyReauthRequired: false,
     });
     const privateData = await getPrivateData();
     if (!privateData?.jwtPrivateKey) {

--- a/apps/server/src/spotify/looper.ts
+++ b/apps/server/src/spotify/looper.ts
@@ -6,6 +6,7 @@ import { RecentlyPlayedTrack } from "../database/schemas/track";
 import { User } from "../database/schemas/user";
 import { HttpError } from "../tools/apis/queueHttpClient";
 import { SpotifyAPI } from "../tools/apis/spotifyApi";
+import { SpotifyReauthRequiredError } from "../tools/errors/Spotify";
 import { logger } from "../tools/logger";
 import { retryPromise, wait } from "../tools/misc";
 import { getTracksAlbumsArtists, storeIterationOfLoop } from "./dbTools";
@@ -111,6 +112,9 @@ export const dbLoop = async () => {
             await loop(us);
           } catch (error) {
             logger.error(`[${us.username}]: Error during refresh`, error);
+            if (error instanceof SpotifyReauthRequiredError) {
+              continue;
+            }
             if (error instanceof HttpError) {
               logger.info("Response of failed request", error.message);
               continue;

--- a/apps/server/src/spotify/looper.ts
+++ b/apps/server/src/spotify/looper.ts
@@ -16,13 +16,9 @@ const RETRY = 10;
 const loop = async (user: User) => {
   logger.info(`[${user.username}]: refreshing...`);
 
-  if (!user.accessToken) {
-    logger.error(
-      `User ${user.username} has not access token, please relog to Spotify`,
-    );
-    return;
-  }
-
+  // No early return on a missing access token: checkToken either refreshes it
+  // or flags the account as needing a reconnection. Returning here left those
+  // accounts silently untracked, even when a refresh could still have worked.
   const url = `/me/player/recently-played?after=${
     user.lastTimestamp - 1000 * 60 * 60 * 2
   }`;

--- a/apps/server/src/tools/apis/spotifyApi.ts
+++ b/apps/server/src/tools/apis/spotifyApi.ts
@@ -57,6 +57,7 @@ export class SpotifyAPI {
           await storeInUser("_id", user._id, {
             accessToken: null,
             refreshToken: null,
+            spotifyReauthRequired: true,
           });
           logger.error(
             `Spotify refresh token for ${user.username} is expired or revoked, discarding it. The user has to re-log to Spotify from the settings page.`,

--- a/apps/server/src/tools/apis/spotifyApi.ts
+++ b/apps/server/src/tools/apis/spotifyApi.ts
@@ -4,6 +4,7 @@ import { getUserFromField, storeInUser } from "../../database";
 import { SpotifyAlbum } from "../../database/schemas/album";
 import { SpotifyArtist } from "../../database/schemas/artist";
 import { SpotifyTrack } from "../../database/schemas/track";
+import { SpotifyReauthRequiredError } from "../errors/Spotify";
 import { logger } from "../logger";
 import { chunk } from "../misc";
 import { spotifyProvider } from "../oauth/Provider";
@@ -42,7 +43,28 @@ export class SpotifyAPI {
       if (!token) {
         throw new Error("User has no refresh token");
       }
-      const infos = await spotifyProvider.refresh(token);
+      let infos;
+      try {
+        infos = await spotifyProvider.refresh(token);
+      } catch (e) {
+        if (
+          e instanceof HttpError &&
+          e.status === 400 &&
+          e.body.includes("invalid_grant")
+        ) {
+          // The refresh token is expired or revoked. Spotify asks us to
+          // discard it without retrying, the user has to sign in again.
+          await storeInUser("_id", user._id, {
+            accessToken: null,
+            refreshToken: null,
+          });
+          logger.error(
+            `Spotify refresh token for ${user.username} is expired or revoked, discarding it. The user has to re-log to Spotify from the settings page.`,
+          );
+          throw new SpotifyReauthRequiredError(user.username);
+        }
+        throw e;
+      }
 
       await storeInUser("_id", user._id, infos);
       logger.info(`Refreshed token for ${user.username}`);

--- a/apps/server/src/tools/apis/spotifyApi.ts
+++ b/apps/server/src/tools/apis/spotifyApi.ts
@@ -41,7 +41,7 @@ export class SpotifyAPI {
     if (Date.now() > user.expiresIn - 1000 * 120) {
       const token = user.refreshToken;
       if (!token) {
-        throw new Error("User has no refresh token");
+        throw new SpotifyReauthRequiredError(user.username);
       }
       let infos;
       try {
@@ -52,16 +52,13 @@ export class SpotifyAPI {
           e.status === 400 &&
           e.body.includes("invalid_grant")
         ) {
-          // The refresh token is expired or revoked. Spotify asks us to
-          // discard it without retrying, the user has to sign in again.
+          // Spotify expires refresh tokens six months after the authorization
+          // and asks us to discard them instead of retrying.
           await storeInUser("_id", user._id, {
             accessToken: null,
             refreshToken: null,
             spotifyReauthRequired: true,
           });
-          logger.error(
-            `Spotify refresh token for ${user.username} is expired or revoked, discarding it. The user has to re-log to Spotify from the settings page.`,
-          );
           throw new SpotifyReauthRequiredError(user.username);
         }
         throw e;

--- a/apps/server/src/tools/apis/spotifyApi.ts
+++ b/apps/server/src/tools/apis/spotifyApi.ts
@@ -24,6 +24,17 @@ interface SpotifyPlaylist {
 export class SpotifyAPI {
   constructor(private readonly userId: string) {}
 
+  // The account cannot authenticate on its own anymore. Discard what is left
+  // and flag it, so the client knows to ask for a Spotify reconnection.
+  private async requireReauth(userId: Types.ObjectId, username: string) {
+    await storeInUser("_id", userId, {
+      accessToken: null,
+      refreshToken: null,
+      spotifyReauthRequired: true,
+    });
+    return new SpotifyReauthRequiredError(username);
+  }
+
   private async checkToken() {
     const user = await getUserFromField(
       "_id",
@@ -41,7 +52,9 @@ export class SpotifyAPI {
     if (Date.now() > user.expiresIn - 1000 * 120) {
       const token = user.refreshToken;
       if (!token) {
-        throw new SpotifyReauthRequiredError(user.username);
+        // Nothing left to refresh with, which is how accounts that were
+        // discarded before the flag existed present themselves.
+        throw await this.requireReauth(user._id, user.username);
       }
       let infos;
       try {
@@ -54,12 +67,7 @@ export class SpotifyAPI {
         ) {
           // Spotify expires refresh tokens six months after the authorization
           // and asks us to discard them instead of retrying.
-          await storeInUser("_id", user._id, {
-            accessToken: null,
-            refreshToken: null,
-            spotifyReauthRequired: true,
-          });
-          throw new SpotifyReauthRequiredError(user.username);
+          throw await this.requireReauth(user._id, user.username);
         }
         throw e;
       }
@@ -68,11 +76,10 @@ export class SpotifyAPI {
       logger.info(`Refreshed token for ${user.username}`);
       access = infos.accessToken;
     }
-    if (access) {
-      return spotifyProvider.getHttpClient(access);
-    } else {
-      throw new Error("Could not get any access token");
+    if (!access) {
+      throw await this.requireReauth(user._id, user.username);
     }
+    return spotifyProvider.getHttpClient(access);
   }
 
   public async raw(url: string) {

--- a/apps/server/src/tools/apis/spotifyApi.ts
+++ b/apps/server/src/tools/apis/spotifyApi.ts
@@ -48,8 +48,10 @@ export class SpotifyAPI {
     if (!user.spotifyId) {
       throw new Error("User has no spotify id");
     }
-    // Refresh the token if it expires in less than two minutes (1000ms * 120)
-    if (Date.now() > user.expiresIn - 1000 * 120) {
+    // Refresh the token if it expires in less than two minutes (1000ms * 120).
+    // A missing access token also goes through the refresh, so a still valid
+    // refresh token is used instead of being discarded further down.
+    if (!access || Date.now() > user.expiresIn - 1000 * 120) {
       const token = user.refreshToken;
       if (!token) {
         // Nothing left to refresh with, which is how accounts that were

--- a/apps/server/src/tools/errors/Spotify.ts
+++ b/apps/server/src/tools/errors/Spotify.ts
@@ -1,0 +1,11 @@
+import { YourSpotifyError } from "./error";
+
+export class SpotifyReauthRequiredError extends YourSpotifyError {
+  public type = "UNAUTHORIZED" as const;
+
+  constructor(username: string) {
+    super(
+      `Spotify refresh token for ${username} is expired or revoked, the user has to re-log to Spotify`,
+    );
+  }
+}

--- a/apps/server/src/tools/errors/Spotify.ts
+++ b/apps/server/src/tools/errors/Spotify.ts
@@ -1,11 +1,11 @@
 import { YourSpotifyError } from "./error";
 
+// Keeps the default UNKNOWN type: the YourSpotify session is still valid, only
+// the Spotify authorization is gone, and a 401 would log the user out.
 export class SpotifyReauthRequiredError extends YourSpotifyError {
-  public type = "UNAUTHORIZED" as const;
-
   constructor(username: string) {
     super(
-      `Spotify refresh token for ${username} is expired or revoked, the user has to re-log to Spotify`,
+      `Spotify authorization of ${username} is no longer valid, the user has to re-log to Spotify`,
     );
   }
 }

--- a/apps/server/src/tools/misc.ts
+++ b/apps/server/src/tools/misc.ts
@@ -1,3 +1,4 @@
+import { SpotifyReauthRequiredError } from "./errors/Spotify";
 import { logger } from "./logger";
 
 export const wait = (ms: number) =>
@@ -289,6 +290,10 @@ export const retryPromise = async <T>(
       const res = await fn();
       return res;
     } catch (e) {
+      if (e instanceof SpotifyReauthRequiredError) {
+        // Retrying cannot succeed until the user re-logs to Spotify.
+        throw e;
+      }
       lastError = e;
       logger.error(
         `Retrying crashed promise, ${i + 1}/${max}${

--- a/apps/server/src/tools/misc.ts
+++ b/apps/server/src/tools/misc.ts
@@ -290,8 +290,8 @@ export const retryPromise = async <T>(
       const res = await fn();
       return res;
     } catch (e) {
+      // Retrying cannot succeed until the user re-logs to Spotify
       if (e instanceof SpotifyReauthRequiredError) {
-        // Retrying cannot succeed until the user re-logs to Spotify.
         throw e;
       }
       lastError = e;


### PR DESCRIPTION
Spotify now expires refresh tokens six months after authorization. This affects all running and future instances of your_spotify. 

I had Claude implement a small pop-up dialog that reminds users to refresh their tokens once in a while:

- Detect invalid_grant, discard the tokens as Spotify asks, and flag the user with spotifyReauthRequired
- Skip the retry loop for that error since retrying cannot succeed
- Record spotifyAuthDate on OAuth callback
- Show a dismissible dialog prompting a re-log, either when the tokens were discarded or when the authorization is over 30 days old

This is a fix for #628. I thought a prompt when opening the dashboard is better than having to go into settings and click re-log every 6 months.